### PR TITLE
Drop rate limit management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     python: "nightly"
 
 before_install:
-  - pip install ".[docs,test,aiohttp,treq]"
+  - pip install -U ".[dev]"
   - pip install -U pytest-cov sphinx
 script:
   - pytest --cov=gidgethub

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,8 @@ Changelog
 2.0.0 (in development)
 ''''''''''''''''''''''
 - Renamed ``gidgethub.abc._sleep()`` to ``sleep()`` to make the method public.
-- Renamed the "test" extra to "tests" and added the "dev" extra
+- Renamed the "test" extra to "tests" and added the "dev" extra.
+- Introduced the ``RateLimitExceeded`` exception.
 
 1.2.0
 ''''''''''''''''''''''

--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,10 @@ cat's name, Gidget, as part of the name. Since "Gidget" somewhat sounds like
 Changelog
 ---------
 
-1.3.0 (in development)
+2.0.0 (in development)
 ''''''''''''''''''''''
+- Renamed ``gidgethub.abc._sleep()`` to ``sleep()`` to make the method public.
+- Renamed the "test" extra to "tests" and added the "dev" extra
 
 1.2.0
 ''''''''''''''''''''''

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,8 @@ Changelog
 - Renamed ``gidgethub.abc._sleep()`` to ``sleep()`` to make the method public.
 - Renamed the "test" extra to "tests" and added the "dev" extra.
 - Introduced the ``RateLimitExceeded`` exception.
+- Methods on ``GitHubAPI`` no longer automatically sleep when it's
+  possible that the call will exceed the user's rate limit.
 
 1.2.0
 ''''''''''''''''''''''

--- a/docs/__init__.rst
+++ b/docs/__init__.rst
@@ -44,6 +44,19 @@ Exceptions
    Inherits from :exc:`HTTPException`.
 
 
+.. exception:: RateLimitExceeded(rate_limit: sansio.RateLimit)
+
+    Raised when one's rate limit has been reached. A subclass of
+    :exc:`BadRequest`.
+
+    .. versionadded:: 2.0
+
+    .. attribute:: rate_limit: sansio.RateLimit
+
+        The :class:`~gidgethub.sansio.RateLimit` object with the rate
+        limit details which triggered the raising of the exception.
+
+
 .. exception:: InvalidField(errors: List[Any], *args: Any)
 
    Raised when a

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -79,11 +79,11 @@ experimental APIs without issue.
         dictionary is expected to work with lower-case keys.
 
 
-    .. abstractcoroutine:: _sleep(seconds: float) -> None
+    .. abstractcoroutine:: sleep(seconds: float) -> None
 
         An abstract :term:`coroutine` which causes the coroutine to
-        sleep for the specified number of seconds. This is used to
-        help prevent the user from going over their request
+        sleep for the specified number of seconds. This is provided to
+        help prevent from going over one's
         `rate limit <https://developer.github.com/v3/#rate-limiting>`_.
 
 

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -86,6 +86,10 @@ experimental APIs without issue.
         help prevent from going over one's
         `rate limit <https://developer.github.com/v3/#rate-limiting>`_.
 
+        .. versionchanged:: 2.0
+
+            Renamed from ``_sleep()``.
+
 
     .. coroutine:: getitem(url: str, url_vars: Dict[str, str] = {}, *, accept=sansio.accept_format()) -> Any
 

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -47,6 +47,13 @@ experimental APIs without issue.
     than ``200``, ``201``, or ``204``, then an appropriate
     :exc:`~gidgethub.HTTPException` is raised.
 
+    .. versionchanged:: 2.0
+        Methods no longer automatically sleep when there is a chance
+        of exceeding the
+        `rate limit <https://developer.github.com/v3/#rate-limiting>`_.
+        This leads to :exc:`~gidgethub.RateLimitExceeded` being raised
+        when the rate limit has been execeeded.
+
 
     .. attribute:: requester
 

--- a/gidgethub/__init__.py
+++ b/gidgethub/__init__.py
@@ -42,11 +42,14 @@ class RateLimitExceeded(BadRequest):
 
     """Request rejected due to the rate limit being exceeded."""
 
-    def __init__(self, rate_limit: "gidgethub.sansio.RateLimit"):
+    def __init__(self, rate_limit: "gidgethub.sansio.RateLimit",*args: Any) -> None:
         self.rate_limit = rate_limit
 
-        super().__init__(http.HTTPStatus.FORBIDDEN,
-                         "rate limit exceeded")
+        if not args:
+            super().__init__(http.HTTPStatus.FORBIDDEN,
+                             "rate limit exceeded")
+        else:
+            super().__init__(http.HTTPStatus.FORBIDDEN, *args)
 
 
 class InvalidField(BadRequest):

--- a/gidgethub/__init__.py
+++ b/gidgethub/__init__.py
@@ -38,6 +38,17 @@ class BadRequest(HTTPException):
     # https://developer.github.com/v3/#client-errors
 
 
+class RateLimitExceeded(BadRequest):
+
+    """Request rejected due to the rate limit being exceeded."""
+
+    def __init__(self, rate_limit: "gidgethub.sansio.RateLimit"):
+        self.rate_limit = rate_limit
+
+        super().__init__(http.HTTPStatus.FORBIDDEN,
+                         "rate limit exceeded")
+
+
 class InvalidField(BadRequest):
 
     """A field in the request is invalid.

--- a/gidgethub/abc.py
+++ b/gidgethub/abc.py
@@ -23,7 +23,7 @@ class GitHubAPI(abc.ABC):
         """Make an HTTP request."""
 
     @abc.abstractmethod
-    async def _sleep(self, seconds: float) -> None:
+    async def sleep(self, seconds: float) -> None:
         """Sleep for the specified number of seconds."""
 
     async def _make_request(self, method: str, url: str,
@@ -42,7 +42,7 @@ class GitHubAPI(abc.ABC):
                 # the same oauth token so the last call will have set the rate_limit accurately.
                 now = datetime.datetime.now(datetime.timezone.utc)
                 wait = self.rate_limit.reset_datetime - now
-                await self._sleep(wait.total_seconds())
+                await self.sleep(wait.total_seconds())
         filled_url = sansio.format_url(url, url_vars)
         request_headers = sansio.create_headers(self.requester, accept=accept,
                                                 oauth_token=self.oauth_token)

--- a/gidgethub/aiohttp.py
+++ b/gidgethub/aiohttp.py
@@ -20,5 +20,5 @@ class GitHubAPI(gh_abc.GitHubAPI):
                                          data=body) as response:
             return response.status, response.headers, await response.read()
 
-    async def _sleep(self, seconds: float) -> None:
+    async def sleep(self, seconds: float) -> None:
         await asyncio.sleep(seconds)

--- a/gidgethub/test/test_abc.py
+++ b/gidgethub/test/test_abc.py
@@ -34,7 +34,7 @@ class MockGitHubAPI(gh_abc.GitHubAPI):
             pass
         return self.response_code, response_headers, self.response_body
 
-    async def _sleep(self, seconds):
+    async def sleep(self, seconds):
         """Sleep for the specified number of seconds."""
         self.slept = seconds
 

--- a/gidgethub/test/test_abc.py
+++ b/gidgethub/test/test_abc.py
@@ -40,33 +40,6 @@ class MockGitHubAPI(gh_abc.GitHubAPI):
 
 
 @pytest.mark.asyncio
-async def test_rate_limit():
-    """The sleep() method is called appropriately if the rate limit is hit."""
-    # Default rate limit does not block.
-    gh = MockGitHubAPI()
-    await gh._make_request("GET", "/rate_limit", {}, "", sansio.accept_format())
-    assert not hasattr(gh, "slept")
-    # No reason to sleep.
-    now = datetime.datetime.now(datetime.timezone.utc)
-    year_from_now = now + datetime.timedelta(365)
-    rate_limit = sansio.RateLimit(limit=2, remaining=1,
-                                  reset_epoch=year_from_now.timestamp())
-    gh.rate_limit = rate_limit
-    await gh._make_request("GET", "/rate_limit", {}, "", sansio.accept_format())
-    assert not hasattr(gh, "slept")
-    # Expected to sleep.
-    rate_limit = sansio.RateLimit(limit=2, remaining=0,
-                                  reset_epoch=year_from_now.timestamp())
-    gh.rate_limit = rate_limit
-    await gh._make_request("GET", "/rate_limit", {}, "", sansio.accept_format())
-    assert hasattr(gh, "slept")
-    # Enough time has passed since year_from_now was calculated that it's safer
-    # to assume that the time left is less then 365 days but more than 364 days.
-    assert gh.slept > datetime.timedelta(364).total_seconds()
-    assert gh.slept <= datetime.timedelta(365).total_seconds()
-
-
-@pytest.mark.asyncio
 async def test_url_formatted():
     """The URL is appropriately formatted."""
     gh = MockGitHubAPI()

--- a/gidgethub/test/test_aiohttp.py
+++ b/gidgethub/test/test_aiohttp.py
@@ -13,7 +13,7 @@ async def test_sleep():
     start = datetime.datetime.now()
     async with aiohttp.ClientSession() as session:
         gh = gh_aiohttp.GitHubAPI(session, "gidgethub")
-        await gh._sleep(delay)
+        await gh.sleep(delay)
     stop = datetime.datetime.now()
     assert (stop - start) > datetime.timedelta(seconds=delay)
 

--- a/gidgethub/test/test_exceptions.py
+++ b/gidgethub/test/test_exceptions.py
@@ -1,7 +1,8 @@
 import http
 
 from .. import (BadRequest, GitHubBroken, HTTPException, InvalidField,
-                RedirectionException)
+                RateLimitExceeded, RedirectionException)
+from .. import sansio
 
 
 class TestHTTPException:
@@ -27,6 +28,11 @@ def test_GitHubBroken():
 def test_BadRequest():
     exc = BadRequest(http.HTTPStatus.BAD_REQUEST)
     assert exc.status_code == http.HTTPStatus.BAD_REQUEST
+
+def test_RateLimitExceeded():
+    rate = sansio.RateLimit(limit=1, remaining=0, reset_epoch=1)
+    exc = RateLimitExceeded(rate)
+    assert exc.status_code == http.HTTPStatus.FORBIDDEN
 
 def test_InvalidField():
     errors = [{"resource": "Issue", "field": "title", "code": "missing_field"}]

--- a/gidgethub/test/test_exceptions.py
+++ b/gidgethub/test/test_exceptions.py
@@ -33,6 +33,8 @@ def test_RateLimitExceeded():
     rate = sansio.RateLimit(limit=1, remaining=0, reset_epoch=1)
     exc = RateLimitExceeded(rate)
     assert exc.status_code == http.HTTPStatus.FORBIDDEN
+    exc = RateLimitExceeded(rate, "stuff happened")
+    assert str(exc) == "stuff happened"
 
 def test_InvalidField():
     errors = [{"resource": "Issue", "field": "title", "code": "missing_field"}]

--- a/gidgethub/test/test_treq.py
+++ b/gidgethub/test/test_treq.py
@@ -21,7 +21,7 @@ class TwistedPluginTestCase(TestCase):
             pool.closeCachedConnections()
 
             # We need to sleep to let the connections hang up.
-            return ensureDeferred(gh._sleep(0.5))
+            return ensureDeferred(gh.sleep(0.5))
 
         return cleanup
 
@@ -33,7 +33,7 @@ class TwistedPluginTestCase(TestCase):
         def test_done(ignored):
             stop = datetime.datetime.now()
             self.assertTrue((stop - start) > datetime.timedelta(seconds=delay))
-        d = ensureDeferred(gh._sleep(delay))
+        d = ensureDeferred(gh.sleep(delay))
         d.addCallback(test_done)
         return d
 

--- a/gidgethub/treq.py
+++ b/gidgethub/treq.py
@@ -38,7 +38,7 @@ class GitHubAPI(gh_abc.GitHubAPI):
         }
         return response.code, response_headers, await response.content()
 
-    async def _sleep(self, seconds: float) -> None:
+    async def sleep(self, seconds: float) -> None:
         d = defer.Deferred()
         self._reactor.callLater(seconds, d.callback, None)
         await d

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,16 @@ import pathlib
 
 import setuptools
 
-
-tests_require = ['pytest>=3.0.0', 'pytest-asyncio']
+docs_requires = ["sphinx"]
+tests_requires = ['pytest>=3.0.0', 'pytest-asyncio']
+aiohttp_requires = ["aiohttp"]
+treq_requires = ["treq", "twisted"]
 
 long_description = pathlib.Path("README.rst").read_text("utf-8")
 
 setuptools.setup(
     name="gidgethub",
-    version="1.3.0.dev1",
+    version="2.0.0.dev1",
     description="An async GitHub API library",
     long_description=long_description,
     url="https://gidgethub.readthedocs.io",
@@ -28,12 +30,13 @@ setuptools.setup(
     zip_safe=True,
     python_requires=">=3.6.0",
     setup_requires=['pytest-runner>=2.11.0'],
-    tests_require=tests_require,
+    tests_require=tests_requires,
     install_requires=['uritemplate>=3.0.0'],
     extras_require={
-        "docs": ["sphinx"],
-        "test": tests_require,
-        "aiohttp": ["aiohttp"],
-        "treq": ["treq", "twisted"],
+        "docs": docs_requires,
+        "tests": tests_requires,
+        "aiohttp": aiohttp_requires,
+        "treq": treq_requires,
+        "dev": docs_requires + tests_requires + aiohttp_requires + treq_requires,
     },
 )


### PR DESCRIPTION
Introduce the RateLimitExceeded exception and drop the automatic sleeping of requests in GitHubAPI.