### PR TITLE
Better handling of GitHub's 422 error.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,9 @@ Changelog
 
 - Provide a human-readable string representation of
   ``gidgethub.sansio.RateLimit``.
+  
+- Use the `message` data as the error message, if the `errors` object
+  was not returned.
 
 
 2.4.1

--- a/gidgethub/sansio.py
+++ b/gidgethub/sansio.py
@@ -290,9 +290,12 @@ def decipher_response(status_code: int, headers: Mapping,
                 if not rate_limit.remaining:
                     raise RateLimitExceeded(rate_limit, message)
             elif status_code == 422:
-                errors = data["errors"]
-                fields = ", ".join(repr(e["field"]) for e in errors)
-                message = f"{message} for {fields}"
+                errors = data.get("errors", None)
+                if errors:
+                    fields = ", ".join(repr(e["field"]) for e in errors)
+                    message = f"{message} for {fields}"
+                else:
+                    message = data["message"]
                 raise InvalidField(errors, message)
         elif status_code >= 300:
             exc_type = RedirectionException

--- a/gidgethub/test/test_sansio.py
+++ b/gidgethub/test/test_sansio.py
@@ -2,7 +2,7 @@ import datetime
 import http
 import json
 import pathlib
-import urllib.parse
+
 
 import pytest
 
@@ -296,6 +296,17 @@ class TestDecipherResponse:
             sansio.decipher_response(status_code, headers, body)
         assert exc_info.value.status_code == http.HTTPStatus(status_code)
         assert str(exc_info.value) == "it went bad for 'title'"
+
+    def test_422_no_errors_object(self):
+        status_code = 422
+        body = json.dumps({"message": "Reference does not exist",
+                           "documentation_url": "https://developer.github.com/v3/git/refs/#delete-a-reference"})
+        body = body.encode("utf-8")
+        headers = {"content-type": "application/json; charset=utf-8"}
+        with pytest.raises(InvalidField) as exc_info:
+            sansio.decipher_response(status_code, headers, body)
+        assert exc_info.value.status_code == http.HTTPStatus(status_code)
+        assert str(exc_info.value) == "Reference does not exist"
 
     def test_3XX(self):
         status_code = 301


### PR DESCRIPTION
If "errors" object was not provided, use the "message" field.

Fixes https://github.com/brettcannon/gidgethub/issues/49