### PR TITLE
Allow authenticating as a GitHub App

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Changelog
 - ``gidgethub.sansio.RateLimit.from_http`` returns ``None`` if ratelimit is
   not found in the headers.
 - Allow authenticating as a GitHub App by using JSON web token.
-  ``gidgethub.abc.GitHubAPI`` and ``gidgethub.sansio.create_headers`` now accepts
+  ``gidgethub.sansio.create_headers`` now accepts
   ``jwt`` argument. ``gidgethub.abc.GitHubAPI._make_request``,
   ``gidgethub.abc.GitHubAPI.getitem``, ``gidgethub.abc.GitHubAPI.getiter``,
   ``gidgethub.abc.GitHubAPI.post``, ``gidgethub.abc.GitHubAPI.patch``,

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,13 @@ Changelog
 
 - ``gidgethub.sansio.RateLimit.from_http`` returns ``None`` if ratelimit is
   not found in the headers.
+- Allow authenticating as a GitHub App by using JSON web token.
+  ``gidgethub.abc.GitHubAPI`` and ``gidgethub.sansio.create_headers`` now accepts
+  ``jwt`` argument. ``gidgethub.abc.GitHubAPI._make_request``,
+  ``gidgethub.abc.GitHubAPI.getitem``, ``gidgethub.abc.GitHubAPI.getiter``,
+  ``gidgethub.abc.GitHubAPI.post``, ``gidgethub.abc.GitHubAPI.patch``,
+  ``gidgethub.abc.GitHubAPI.put``, and ``gidgethub.abc.GitHubAPI.delete`` are now
+  accepting ``auth_type`` and ``token`` arguments.
 
 2.5.0
 '''''

--- a/README.rst
+++ b/README.rst
@@ -68,8 +68,8 @@ Changelog
   ``jwt`` argument. ``gidgethub.abc.GitHubAPI._make_request``,
   ``gidgethub.abc.GitHubAPI.getitem``, ``gidgethub.abc.GitHubAPI.getiter``,
   ``gidgethub.abc.GitHubAPI.post``, ``gidgethub.abc.GitHubAPI.patch``,
-  ``gidgethub.abc.GitHubAPI.put``, and ``gidgethub.abc.GitHubAPI.delete`` are now
-  accepting ``auth_type`` and ``token`` arguments.
+  ``gidgethub.abc.GitHubAPI.put``, and ``gidgethub.abc.GitHubAPI.delete`` now
+  accept``jwt`` and ``oauth_token`` arguments.
 
 2.5.0
 '''''

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -24,7 +24,7 @@ does not require an update to the library, allowing one to use
 experimental APIs without issue.
 
 
-.. class:: GitHubAPI(requester, *, oauth_token=None, cache=None, jwt=None)
+.. class:: GitHubAPI(requester, *, oauth_token=None, cache=None)
 
     Provide an :py:term:`abstract base class` which abstracts out the
     HTTP library being used to send requests to GitHub. The class is
@@ -66,8 +66,6 @@ experimental APIs without issue.
     .. versionchanged:: 2.3
         Introduced the *cache* argument to the constructor.
 
-    .. versionchanged:: 3.0
-        Introduced the *jwt* argument to the constructor.
 
     .. attribute:: requester
 
@@ -79,9 +77,6 @@ experimental APIs without issue.
 
         The provided OAuth token (if any).
 
-    .. attribute:: jwt
-
-       The provided JSON web token (if any).
 
     .. attribute:: rate_limit
 

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -24,7 +24,7 @@ does not require an update to the library, allowing one to use
 experimental APIs without issue.
 
 
-.. class:: GitHubAPI(requester, *, oauth_token=None, cache=None)
+.. class:: GitHubAPI(requester, *, oauth_token=None, cache=None, jwt=None)
 
     Provide an :py:term:`abstract base class` which abstracts out the
     HTTP library being used to send requests to GitHub. The class is
@@ -66,6 +66,8 @@ experimental APIs without issue.
     .. versionchanged:: 2.3
         Introduced the *cache* argument to the constructor.
 
+    .. versionchanged:: 3.0
+        Introduced the *jwt* argument to the constructor.
 
     .. attribute:: requester
 
@@ -77,6 +79,9 @@ experimental APIs without issue.
 
         The provided OAuth token (if any).
 
+    .. attribute:: jwt
+
+       The provided JSON web token (if any).
 
     .. attribute:: rate_limit
 
@@ -84,7 +89,6 @@ experimental APIs without issue.
         representing the last known rate limit imposed upon the user.
         This attribute is automatically updated after every successful
         HTTP request.
-
 
     .. abstractcoroutine:: _request(method, url, headers, body=b'')
 
@@ -110,16 +114,26 @@ experimental APIs without issue.
             Renamed from ``_sleep()``.
 
 
-    .. coroutine:: getitem(url, url_vars={}, *, accept=sansio.accept_format())
+    .. coroutine:: getitem(url, url_vars={}, *, accept=sansio.accept_format(), auth_type=None, token=None)
 
         Get a single item from GitHub.
+
+        *auth_type* is the authentication type, either ``"oauth"`` or ``"jwt"``.
+        Defaults to ``"oauth"``.
+
+        *token* is the value of the authentication token. Defaults to the value
+        of the value of the *oauth_token* attribute.
+
+        .. versionchanged:: 3.0
+
+            Added *auth_type* and *token*.
 
         .. note::
             For ``GET`` calls that can return multiple values and
             potentially require pagination, see ``getiter()``.
 
 
-    .. coroutine:: getiter(url, url_vars={}, *, accept=sansio.accept_format())
+    .. coroutine:: getiter(url, url_vars={}, *, accept=sansio.accept_format(), auth_type=None, token=None)
 
         Get all items from a GitHub API endpoint.
 
@@ -128,21 +142,52 @@ experimental APIs without issue.
         `pagination <https://developer.github.com/v3/#pagination>`_
         will automatically be followed.
 
+        *auth_type* is the authentication type, either ``"oauth"`` or ``"jwt"``.
+        Defaults to ``"oauth"``.
+
+        *token* is the value of the authentication token. Defaults to the value
+        of the value of the *oauth_token* attribute.
+
+        .. versionchanged:: 3.0
+
+            Added *auth_type* and *token*.
+
         .. note::
             For ``GET`` calls that return only a single item, see
             :meth:`getitem`.
 
-    .. coroutine:: post(url, url_vars={}, *, data, accept=sansio.accept_format())
+
+    .. coroutine:: post(url, url_vars={}, *, data, accept=sansio.accept_format(), auth_type=None, token=None)
 
         Send a ``POST`` request to GitHub.
 
+        *auth_type* is the authentication type, either ``"oauth"`` or ``"jwt"``.
+        Defaults to ``"oauth"``.
 
-    .. coroutine:: patch(url, url_vars={}, *, data, accept=sansio.accept_format())
+        *token* is the value of the authentication token. Defaults to the value
+        of the value of the *oauth_token* attribute.
+
+        .. versionchanged:: 3.0
+
+            Added *auth_type* and *token*.
+
+
+    .. coroutine:: patch(url, url_vars={}, *, data, accept=sansio.accept_format(), auth_type=None, token=None)
 
         Send a ``PATCH`` request to GitHub.
 
+        *auth_type* is the authentication type, either ``"oauth"`` or ``"jwt"``.
+        Defaults to ``"oauth"``.
 
-    .. coroutine:: put(url, url_vars={}, *, data=b"", accept=sansio.accept_format())
+        *token* is the value of the authentication token. Defaults to the value
+        of the value of the *oauth_token* attribute.
+
+        .. versionchanged:: 3.0
+
+            Added *auth_type* and *token*.
+
+
+    .. coroutine:: put(url, url_vars={}, *, data=b"", accept=sansio.accept_format(), auth_type=None, token=None)
 
         Send a ``PUT`` request to GitHub.
 
@@ -150,7 +195,25 @@ experimental APIs without issue.
         `locking an issue <https://developer.github.com/v3/issues/#lock-an-issue>`_
         will return no content, leading to ``None`` being returned.
 
+        *auth_type* is the authentication type, either ``"oauth"`` or ``"jwt"``.
+        Defaults to ``"oauth"``.
 
-    .. coroutine:: delete(url, url_vars={}, *, data=b"", accept=sansio.accept_format())
+        *token* is the value of the authentication token. Defaults to the value
+        of the value of the *oauth_token* attribute.
+
+        .. versionchanged:: 3.0
+
+            Added *auth_type* and *token*.
+
+
+    .. coroutine:: delete(url, url_vars={}, *, data=b"", accept=sansio.accept_format(), auth_type=None, token=None)
 
         Send a ``DELETE`` request to GitHub.
+
+        .. versionchanged:: 2.5
+
+            Added *data* argument.
+
+        .. versionchanged:: 3.0
+
+            Added *auth_type* and *token*.

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -109,26 +109,30 @@ experimental APIs without issue.
             Renamed from ``_sleep()``.
 
 
-    .. coroutine:: getitem(url, url_vars={}, *, accept=sansio.accept_format(), auth_type=None, token=None)
+    .. coroutine:: getitem(url, url_vars={}, *, accept=sansio.accept_format(), jwt=None, oauth_token=None)
 
         Get a single item from GitHub.
 
-        *auth_type* is the authentication type, either ``"oauth"`` or ``"jwt"``.
-        Defaults to ``"oauth"``.
+        *jwt* is the value of the JSON web token, for authenticating as a GitHub
+        App.
 
-        *token* is the value of the authentication token. Defaults to the value
-        of the value of the *oauth_token* attribute.
+        *oauth_token* is the value of the oauth token, for making an authenticated
+        API call.
+
+        Only one of *oauth_token* or *jwt* may be passed. A ``ValueError`` is
+        raised if both are passed. If neither was passed, it defaults to the
+        value of the *oauth_token* attribute.
 
         .. versionchanged:: 3.0
 
-            Added *auth_type* and *token*.
+            Added *jwt* and *oauth_token*.
 
         .. note::
             For ``GET`` calls that can return multiple values and
             potentially require pagination, see ``getiter()``.
 
 
-    .. coroutine:: getiter(url, url_vars={}, *, accept=sansio.accept_format(), auth_type=None, token=None)
+    .. coroutine:: getiter(url, url_vars={}, *, accept=sansio.accept_format(), jwt=None, oauth_token=None)
 
         Get all items from a GitHub API endpoint.
 
@@ -137,52 +141,64 @@ experimental APIs without issue.
         `pagination <https://developer.github.com/v3/#pagination>`_
         will automatically be followed.
 
-        *auth_type* is the authentication type, either ``"oauth"`` or ``"jwt"``.
-        Defaults to ``"oauth"``.
+        *jwt* is the value of the JSON web token, for authenticating as a GitHub
+        App.
 
-        *token* is the value of the authentication token. Defaults to the value
-        of the value of the *oauth_token* attribute.
+        *oauth_token* is the value of the oauth token, for making an authenticated
+        API call.
+
+        Only one of *oauth_token* or *jwt* may be passed. A ``ValueError`` is
+        raised if both are passed. If neither was passed, it defaults to the
+        value of the *oauth_token* attribute.
 
         .. versionchanged:: 3.0
 
-            Added *auth_type* and *token*.
+            Added *jwt* and *oauth_token*.
 
         .. note::
             For ``GET`` calls that return only a single item, see
             :meth:`getitem`.
 
 
-    .. coroutine:: post(url, url_vars={}, *, data, accept=sansio.accept_format(), auth_type=None, token=None)
+    .. coroutine:: post(url, url_vars={}, *, data, accept=sansio.accept_format(), jwt=None, oauth_token=None)
 
         Send a ``POST`` request to GitHub.
 
-        *auth_type* is the authentication type, either ``"oauth"`` or ``"jwt"``.
-        Defaults to ``"oauth"``.
+        *jwt* is the value of the JSON web token, for authenticating as a GitHub
+        App.
 
-        *token* is the value of the authentication token. Defaults to the value
-        of the value of the *oauth_token* attribute.
+        *oauth_token* is the value of the oauth token, for making an authenticated
+        API call.
+
+        Only one of *oauth_token* or *jwt* may be passed. A ``ValueError`` is
+        raised if both are passed. If neither was passed, it defaults to the
+        value of the *oauth_token* attribute.
 
         .. versionchanged:: 3.0
 
-            Added *auth_type* and *token*.
+            Added *jwt* and *oauth_token*.
 
 
-    .. coroutine:: patch(url, url_vars={}, *, data, accept=sansio.accept_format(), auth_type=None, token=None)
+    .. coroutine:: patch(url, url_vars={}, *, data, accept=sansio.accept_format(), jwt=None, oauth_token=None)
 
         Send a ``PATCH`` request to GitHub.
 
-        *auth_type* is the authentication type, either ``"oauth"`` or ``"jwt"``.
-        Defaults to ``"oauth"``.
+        *jwt* is the value of the JSON web token, for authenticating as a GitHub
+        App.
 
-        *token* is the value of the authentication token. Defaults to the value
-        of the value of the *oauth_token* attribute.
+        *oauth_token* is the value of the oauth token, for making an authenticated
+        API call.
+
+        Only one of *oauth_token* or *jwt* may be passed. A ``ValueError`` is
+        raised if both are passed. If neither was passed, it defaults to the
+        value of the *oauth_token* attribute.
 
         .. versionchanged:: 3.0
 
-            Added *auth_type* and *token*.
+            Added *jwt* and *oauth_token*.
 
 
-    .. coroutine:: put(url, url_vars={}, *, data=b"", accept=sansio.accept_format(), auth_type=None, token=None)
+    .. coroutine:: put(url, url_vars={}, *, data=b"", accept=sansio.accept_format(), jwt=None, oauth_token=None)
 
         Send a ``PUT`` request to GitHub.
 
@@ -190,20 +206,34 @@ experimental APIs without issue.
         `locking an issue <https://developer.github.com/v3/issues/#lock-an-issue>`_
         will return no content, leading to ``None`` being returned.
 
-        *auth_type* is the authentication type, either ``"oauth"`` or ``"jwt"``.
-        Defaults to ``"oauth"``.
+        *jwt* is the value of the JSON web token, for authenticating as a GitHub
+        App.
 
-        *token* is the value of the authentication token. Defaults to the value
-        of the value of the *oauth_token* attribute.
+        *oauth_token* is the value of the oauth token, for making an authenticated
+        API call.
+
+        Only one of *oauth_token* or *jwt* may be passed. A ``ValueError`` is
+        raised if both are passed. If neither was passed, it defaults to the
+        value of the *oauth_token* attribute.
 
         .. versionchanged:: 3.0
 
-            Added *auth_type* and *token*.
+            Added *jwt* and *oauth_token*.
 
 
-    .. coroutine:: delete(url, url_vars={}, *, data=b"", accept=sansio.accept_format(), auth_type=None, token=None)
+    .. coroutine:: delete(url, url_vars={}, *, data=b"", accept=sansio.accept_format(), jwt=None, oauth_token=None)
 
         Send a ``DELETE`` request to GitHub.
+
+        *jwt* is the value of the JSON web token, for authenticating as a GitHub
+        App.
+
+        *oauth_token* is the value of the oauth token, for making an authenticated
+        API call.
+
+        Only one of *oauth_token* or *jwt* may be passed. A ``ValueError`` is
+        raised if both are passed. If neither was passed, it defaults to the
+        value of the *oauth_token* attribute.
 
         .. versionchanged:: 2.5
 
@@ -211,4 +241,4 @@ experimental APIs without issue.
 
         .. versionchanged:: 3.0
 
-            Added *auth_type* and *token*.
+            Added *jwt* and *oauth_token*.

--- a/docs/sansio.rst
+++ b/docs/sansio.rst
@@ -122,7 +122,7 @@ by helping to automate the GitHub-specific aspects of a REST call.
    support.
 
 
-.. function:: create_headers(requester, *, accept=accept_format(), oauth_token=None)
+.. function:: create_headers(requester, *, accept=accept_format(), oauth_token=None, jwt=None)
 
    Create a dict representing GitHub-specific header fields.
 
@@ -141,7 +141,17 @@ by helping to automate the GitHub-specific aspects of a REST call.
    This can be important if you need the expanded rate limit provided by an
    authenticated request.
 
+   The *jwt* allows making an authenticated request as a `GitHub App
+   <https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app>`_.
+   You can pass only one: *oauth_token* or *jwt*, but not both.
+
+   ``ValueError`` will be raised if both *jwt* and *oauth_token* are supplied.
+
    For consistency, all keys in the returned dict will be lowercased.
+
+   .. versionchanged:: 3.0
+
+       Added ``jwt`` argument.
 
 
 Responses
@@ -200,6 +210,9 @@ that are provided to you. Continuing from the example in the Requests_ section::
         Create a :class:`RateLimit` instance from the HTTP headers of a GitHub API
         response.  Returns ``None`` if the ratelimit is not found in the headers.
 
+        .. versionchanged:: 3.0
+
+            Returns ``None`` if the ratelimit is not found in the headers.
 
 .. function:: decipher_response(status_code, headers, body)
 

--- a/gidgethub/abc.py
+++ b/gidgethub/abc.py
@@ -38,7 +38,6 @@ class GitHubAPI(abc.ABC):
                             ) -> Tuple[bytes, Opt[str]]:
         """Construct and make an HTTP request."""
         filled_url = sansio.format_url(url, url_vars)
-        print(f"filled url {filled_url}")
         if auth_type == "jwt" and token is not None:
             request_headers = sansio.create_headers(
                 self.requester, accept=accept,
@@ -52,8 +51,6 @@ class GitHubAPI(abc.ABC):
             request_headers = sansio.create_headers(
                 self.requester, accept=accept,
                 oauth_token=self.oauth_token)
-        print("headers")
-        print(request_headers)
         cached = cacheable = False
         # Can't use None as a "no body" sentinel as it's a legitimate JSON type.
         if data == b"":

--- a/gidgethub/abc.py
+++ b/gidgethub/abc.py
@@ -16,9 +16,11 @@ class GitHubAPI(abc.ABC):
     """Provide an idiomatic API for making calls to GitHub's API."""
 
     def __init__(self, requester: str, *, oauth_token: Opt[str] = None,
+                 jwt: Opt[str] = None,
                  cache: Opt[CACHE_TYPE] = None) -> None:
         self.requester = requester
         self.oauth_token = oauth_token
+        self.jwt = jwt
         self._cache = cache
         self.rate_limit: Opt[sansio.RateLimit] = None
 
@@ -32,11 +34,31 @@ class GitHubAPI(abc.ABC):
         """Sleep for the specified number of seconds."""
 
     async def _make_request(self, method: str, url: str, url_vars: Dict,
-                            data: Any, accept: str) -> Tuple[bytes, Opt[str]]:
+                            data: Any, accept: str,
+                            auth_type: Opt[str] = None,
+                            token: Opt[str] = None,
+                            ) -> Tuple[bytes, Opt[str]]:
         """Construct and make an HTTP request."""
         filled_url = sansio.format_url(url, url_vars)
-        request_headers = sansio.create_headers(self.requester, accept=accept,
-                                                oauth_token=self.oauth_token)
+        if auth_type == "oauth" and token is not None:
+            request_headers = sansio.create_headers(
+                self.requester, accept=accept,
+                oauth_token=token)
+        elif auth_type == "jwt":
+            if token:
+                request_headers = sansio.create_headers(
+                    self.requester, accept=accept,
+                    jwt=token)
+            else:
+                request_headers = sansio.create_headers(
+                    self.requester, accept=accept,
+                    jwt=self.jwt)
+        else:
+            # fallback to using oauth_token
+            request_headers = sansio.create_headers(
+                self.requester, accept=accept,
+                oauth_token=self.oauth_token)
+
         cached = cacheable = False
         # Can't use None as a "no body" sentinel as it's a legitimate JSON type.
         if data == b"":
@@ -73,37 +95,62 @@ class GitHubAPI(abc.ABC):
         return data, more
 
     async def getitem(self, url: str, url_vars: Dict = {},
-                      *, accept: str = sansio.accept_format()) -> Any:
+                      *, accept: str = sansio.accept_format(),
+                      auth_type: Opt[str] = None,
+                      token: Opt[str] = None
+                      ) -> Any:
         """Send a GET request for a single item to the specified endpoint."""
-        data, _ = await self._make_request("GET", url, url_vars, b"", accept)
+        data, _ = await self._make_request("GET", url, url_vars, b"", accept,
+                                           auth_type=auth_type, token=token)
         return data
 
     async def getiter(self, url: str, url_vars: Dict = {},
-                      *, accept: str = sansio.accept_format()) -> AsyncGenerator[Any, None]:
+                      *, accept: str = sansio.accept_format(),
+                      auth_type: Opt[str] = None,
+                      token: Opt[str] = None
+                      ) -> AsyncGenerator[Any, None]:
         """Return an async iterable for all the items at a specified endpoint."""
-        data, more = await self._make_request("GET", url, url_vars, b"", accept)
+        data, more = await self._make_request("GET", url, url_vars, b"", accept,
+                                           auth_type=auth_type, token=token)
         for item in data:
             yield item
         if more:
             # `yield from` is not supported in coroutines.
-            async for item in self.getiter(more, url_vars, accept=accept):
+            async for item in self.getiter(more, url_vars, accept=accept,
+                                           auth_type=auth_type, token=token):
                 yield item
 
     async def post(self, url: str, url_vars: Dict = {}, *, data: Any,
-                   accept: str = sansio.accept_format()) -> Any:
-        data, _ = await self._make_request("POST", url, url_vars, data, accept)
+                   accept: str = sansio.accept_format(),
+                   auth_type: Opt[str] = None,
+                   token: Opt[str] = None
+                   ) -> Any:
+        data, _ = await self._make_request("POST", url, url_vars, data, accept,
+                                           auth_type=auth_type, token=token)
         return data
 
     async def patch(self, url: str, url_vars: Dict = {}, *, data: Any,
-                    accept: str = sansio.accept_format()) -> Any:
-        data, _ = await self._make_request("PATCH", url, url_vars, data, accept)
+                    accept: str = sansio.accept_format(),
+                    auth_type: Opt[str] = None,
+                    token: Opt[str] = None
+                    ) -> Any:
+        data, _ = await self._make_request("PATCH", url, url_vars, data, accept,
+                                           auth_type=auth_type, token=token)
         return data
 
     async def put(self, url: str, url_vars: Dict = {}, *, data: Any = b"",
-                  accept: str = sansio.accept_format()) -> Any:
-        data, _ = await self._make_request("PUT", url, url_vars, data, accept)
+                  accept: str = sansio.accept_format(),
+                  auth_type: Opt[str] = None,
+                  token: Opt[str] = None
+                  ) -> Any:
+        data, _ = await self._make_request("PUT", url, url_vars, data, accept,
+                                           auth_type=auth_type, token=token)
         return data
 
     async def delete(self, url: str, url_vars: Dict = {}, *, data: Any = b"",
-                     accept: str = sansio.accept_format()) -> None:
-        await self._make_request("DELETE", url, url_vars, data, accept)
+                     accept: str = sansio.accept_format(),
+                     auth_type: Opt[str] = None,
+                     token: Opt[str] = None
+                     ) -> None:
+        await self._make_request("DELETE", url, url_vars, data, accept,
+                                           auth_type=auth_type, token=token)

--- a/gidgethub/sansio.py
+++ b/gidgethub/sansio.py
@@ -146,7 +146,8 @@ def accept_format(*, version: str = "v3", media: Optional[str] = None,
 
 
 def create_headers(requester: str, *, accept: str = accept_format(),
-                   oauth_token: Optional[str] = None) -> Dict[str, str]:
+                   oauth_token: Optional[str] = None,
+                   jwt: Optional[str] = None) -> Dict[str, str]:
     """Create a dict representing GitHub-specific header fields.
 
     The user agent is set according to who the requester is. GitHub asks it be
@@ -158,9 +159,14 @@ def create_headers(requester: str, *, accept: str = accept_format(),
     development -- or if you are looking for a different format return type,
     e.g. wanting the rendered HTML of a Markdown file.
 
-    The oauth_token allows making an authenticated request. This can be
-    important if you need the expanded rate limit provided by an authenticated
-    request.
+    The 'oauth_token' allows making an authenticated request using a personal access
+    token. This can be important if you need the expanded rate limit provided
+    by an authenticated request.
+
+    The 'jwt' allows authenticating as a GitHub App by passing in the
+    bearer token.
+
+    You can only supply only one of oauth_token or jwt, not both.
 
     For consistency, all keys in the returned dict will be lowercased.
     """
@@ -168,9 +174,15 @@ def create_headers(requester: str, *, accept: str = accept_format(),
     # accept: https://developer.github.com/v3/#current-version
     #         https://developer.github.com/v3/media/
     # authorization: https://developer.github.com/v3/#authentication
+    # authenticating as a GitHub App: https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app
+
+    if oauth_token is not None and jwt is not None:
+        raise ValueError("Cannot pass both oauth_token and jwt.")
     headers = {"user-agent": requester, "accept": accept}
     if oauth_token is not None:
         headers["authorization"] = f"token {oauth_token}"
+    elif jwt is not None:
+        headers["authorization"] = f"bearer {jwt}"
     return headers
 
 

--- a/gidgethub/test/test_abc.py
+++ b/gidgethub/test/test_abc.py
@@ -251,7 +251,7 @@ async def test_getiter_cannot_pass_both_oauth_and_jwt():
         async for _ in gh.getiter("/fake", {"extra": "stuff"},
                                      oauth_token="my oauth token",
                                      jwt="json web token"):
-            pass # pragma: no cover
+            pytest.fail("Unreachable")  # pragma: no cover
     assert str(exc_info.value) == "Cannot pass both oauth_token and jwt."
 
 

--- a/gidgethub/test/test_abc.py
+++ b/gidgethub/test/test_abc.py
@@ -182,7 +182,6 @@ async def test_getiter_with_passed_jwt():
                                  auth_type="jwt", token="json web token"):
         data.append(item)
     assert gh.method == "GET"
-    print(gh.headers)
     assert gh.headers["authorization"] == "bearer json web token"
 
 
@@ -302,8 +301,6 @@ async def test_delete_with_passed_jwt():
                        body=json.dumps(receive).encode("utf-8"))
     await gh.delete("/fake", data=send, auth_type="jwt", token="json web token")
     assert gh.method == "DELETE"
-    print("gh headers")
-    print(gh.headers)
     assert gh.headers["authorization"] == "bearer json web token"
 
 

--- a/gidgethub/test/test_abc.py
+++ b/gidgethub/test/test_abc.py
@@ -170,6 +170,19 @@ async def test_getitem_with_passed_oauth_token():
 
 
 @pytest.mark.asyncio
+async def test_getitem_cannot_pass_both_jwt_and_oauth_token():
+    original_data = {"hello": "world"}
+    headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
+    headers['content-type'] = "application/json; charset=UTF-8"
+    gh = MockGitHubAPI(headers=headers,
+                       body=json.dumps(original_data).encode("utf8"))
+    with pytest.raises(ValueError) as exc_info:
+        await gh.getitem("/fake", oauth_token="my oauth token", jwt="json web token")
+
+    assert str(exc_info.value) == "Cannot pass both oauth_token and jwt."
+
+
+@pytest.mark.asyncio
 async def test_getiter():
     """Test that getiter() returns an async iterable as well as URI expansion."""
     original_data = [1, 2]
@@ -202,7 +215,7 @@ async def test_getiter_with_passed_jwt():
                        body=json.dumps(original_data).encode("utf8"))
     data = []
     async for item in gh.getiter("/fake", {"extra": "stuff"},
-                                jwt="json web token"):
+                                 jwt="json web token"):
         data.append(item)
     assert gh.method == "GET"
     assert gh.headers["authorization"] == "bearer json web token"
@@ -219,10 +232,27 @@ async def test_getiter_with_passed_oauth_token():
                        body=json.dumps(original_data).encode("utf8"))
     data = []
     async for item in gh.getiter("/fake", {"extra": "stuff"},
-                                oauth_token="my oauth token"):
+                                 oauth_token="my oauth token"):
         data.append(item)
     assert gh.method == "GET"
     assert gh.headers["authorization"] == "token my oauth token"
+
+
+@pytest.mark.asyncio
+async def test_getiter_cannot_pass_both_oauth_and_jwt():
+    original_data = [1, 2]
+    next_url = "https://api.github.com/fake{/extra}?page=2"
+    headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
+    headers['content-type'] = "application/json; charset=UTF-8"
+    headers["link"] = f'<{next_url}>; rel="next"'
+    gh = MockGitHubAPI(headers=headers,
+                       body=json.dumps(original_data).encode("utf8"))
+    with pytest.raises(ValueError) as exc_info:
+        async for _ in gh.getiter("/fake", {"extra": "stuff"},
+                                     oauth_token="my oauth token",
+                                     jwt="json web token"):
+            pass # pragma: no cover
+    assert str(exc_info.value) == "Cannot pass both oauth_token and jwt."
 
 
 @pytest.mark.asyncio
@@ -266,6 +296,18 @@ async def test_post_with_passed_oauth_token():
     assert gh.method == "POST"
     assert gh.headers["authorization"] == "token my oauth token"
 
+@pytest.mark.asyncio
+async def test_post_cannot_pass_both_oauth_and_jwt():
+    send = [1, 2, 3]
+    receive = {"hello": "world"}
+    headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
+    headers['content-type'] = "application/json; charset=utf-8"
+    gh = MockGitHubAPI(headers=headers,
+                       body=json.dumps(receive).encode("utf-8"))
+    with pytest.raises(ValueError) as exc_info:
+        await gh.post("/fake", data=send, oauth_token="my oauth token", jwt="json web token")
+
+    assert str(exc_info.value) == "Cannot pass both oauth_token and jwt."
 
 @pytest.mark.asyncio
 async def test_patch():
@@ -308,6 +350,18 @@ async def test_patch_with_passed_oauth_token():
     assert gh.method == "PATCH"
     assert gh.headers["authorization"] == "token my oauth token"
 
+@pytest.mark.asyncio
+async def test_patch_cannot_pass_both_oauth_and_jwt():
+    send = [1, 2, 3]
+    receive = {"hello": "world"}
+    headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
+    headers['content-type'] = "application/json; charset=utf-8"
+    gh = MockGitHubAPI(headers=headers,
+                       body=json.dumps(receive).encode("utf-8"))
+    with pytest.raises(ValueError) as exc_info:
+        await gh.patch("/fake", data=send, oauth_token="my oauth token", jwt="json web token")
+
+    assert str(exc_info.value) == "Cannot pass both oauth_token and jwt."
 
 @pytest.mark.asyncio
 async def test_put():
@@ -352,6 +406,20 @@ async def test_put_with_passed_oauth_token():
 
 
 @pytest.mark.asyncio
+async def test_put_cannot_pass_both_oauth_and_jwt():
+    send = [1, 2, 3]
+    receive = {"hello": "world"}
+    headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
+    headers['content-type'] = "application/json; charset=utf-8"
+    gh = MockGitHubAPI(headers=headers,
+                       body=json.dumps(receive).encode("utf-8"))
+    with pytest.raises(ValueError) as exc_info:
+        await gh.put("/fake", data=send, oauth_token="my oauth token", jwt="json web token")
+
+    assert str(exc_info.value) == "Cannot pass both oauth_token and jwt."
+
+
+@pytest.mark.asyncio
 async def test_delete():
     send = [1, 2, 3]
     send_json = json.dumps(send).encode("utf-8")
@@ -391,6 +459,20 @@ async def test_delete_with_passed_oauth_token():
     await gh.delete("/fake", data=send, oauth_token="my oauth token")
     assert gh.method == "DELETE"
     assert gh.headers["authorization"] == "token my oauth token"
+
+
+@pytest.mark.asyncio
+async def test_delete_pass_both_oauth_and_jwt():
+    send = [1, 2, 3]
+    receive = {"hello": "world"}
+    headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
+    headers['content-type'] = "application/json; charset=utf-8"
+    gh = MockGitHubAPI(headers=headers,
+                       body=json.dumps(receive).encode("utf-8"))
+    with pytest.raises(ValueError) as exc_info:
+        await gh.delete("/fake", data=send, oauth_token="my oauth token", jwt="json web token")
+
+    assert str(exc_info.value) == "Cannot pass both oauth_token and jwt."
 
 
 class TestCache:

--- a/gidgethub/test/test_abc.py
+++ b/gidgethub/test/test_abc.py
@@ -65,7 +65,7 @@ async def test_headers():
 
 @pytest.mark.asyncio
 async def test_auth_headers_with_passed_token():
-    """Test the authorization header with the passed oauth_token"""
+    """Test the authorization header with the passed oauth_token."""
     accept = sansio.accept_format()
     gh = MockGitHubAPI()
     await gh._make_request("GET", "/rate_limit", {}, "", accept,
@@ -77,7 +77,7 @@ async def test_auth_headers_with_passed_token():
 
 @pytest.mark.asyncio
 async def test_auth_headers_with_passed_jwt():
-    """Test the authorization header with the passed jwt"""
+    """Test the authorization header with the passed jwt."""
     accept = sansio.accept_format()
     gh = MockGitHubAPI()
     await gh._make_request("GET", "/rate_limit", {}, "", accept,
@@ -89,7 +89,7 @@ async def test_auth_headers_with_passed_jwt():
 
 @pytest.mark.asyncio
 async def test_make_request_passing_token_and_jwt():
-    """Test that passing both jwt and oauth_token raises ValueError"""
+    """Test that passing both jwt and oauth_token raises ValueError."""
     accept = sansio.accept_format()
     gh = MockGitHubAPI()
     with pytest.raises(ValueError) as exc_info:

--- a/gidgethub/test/test_sansio.py
+++ b/gidgethub/test/test_sansio.py
@@ -166,6 +166,24 @@ class TestCreateHeaders:
         assert headers["accept"] == test_api
         assert headers["authorization"] == f"token {oauth_token}"
 
+    def test_authorization_with_jwt(self):
+        user_agent = "brettcannon"
+        jwt = "secret"
+        headers = sansio.create_headers(user_agent, jwt=jwt)
+        assert headers["user-agent"] == user_agent
+        assert headers["authorization"] == f"bearer {jwt}"
+
+    def test_cannot_pass_both_jwt_and_oauth(self):
+        user_agent = "brettcannon"
+        jwt = "secret jwt"
+        oauth_token = "secret oauth token"
+        with pytest.raises(ValueError) as exc_info:
+            headers = sansio.create_headers(
+                user_agent,
+                oauth_token=oauth_token,
+                jwt=jwt)
+        assert str(exc_info.value) == "Cannot pass both oauth_token and jwt."
+
 
 class TestRateLimit:
 

--- a/gidgethub/test/test_sansio.py
+++ b/gidgethub/test/test_sansio.py
@@ -178,7 +178,7 @@ class TestCreateHeaders:
         jwt = "secret jwt"
         oauth_token = "secret oauth token"
         with pytest.raises(ValueError) as exc_info:
-            headers = sansio.create_headers(
+            sansio.create_headers(
                 user_agent,
                 oauth_token=oauth_token,
                 jwt=jwt)


### PR DESCRIPTION
- Add `jwt` and `oauth_token` parameters to:
  * `abc.GitHubAPI._make_request`
  * `abc.GitHubAPI.get_item`
  * `abc.GitHubAPI.get_iter`
  * `abc.GitHubAPI.post`
  * `abc.GitHubAPI.patch`
  * `abc.GitHubAPI.put`
  * `abc.GitHubAPI.delete`
- Add `jwt` argument to `sansio.create_headers`
- Raise `ValueError` if both `jwt` and `oauth_token` are passed in above methods
- Update the documentation
- Update the changelog

Closes https://github.com/brettcannon/gidgethub/issues/23