### PR TITLE
Fix development version number, per PEP 440

### DIFF
--- a/gidgethub/__init__.py
+++ b/gidgethub/__init__.py
@@ -1,5 +1,5 @@
 """An async GitHub API library"""
-__version__ = '3.0.0.dev'
+__version__ = '3.0.0.dev0'
 
 import http
 from typing import Any

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ long_description = pathlib.Path("README.rst").read_text("utf-8")
 
 setuptools.setup(
     name="gidgethub",
-    version="3.0.0.dev",
+    version="3.0.0.dev0",
     description="An async GitHub API library",
     long_description=long_description,
     url="https://gidgethub.readthedocs.io",


### PR DESCRIPTION
Change the version from 3.0.0.dev -> 3.0.0.dev0.

I saw this warning from `flit`.
```
Version number normalised: '3.0.0.dev' -> '3.0.0.dev0' (see PEP 440)                                  W-flit.validate
```

I haven't got it to work with flit yet, but figured this change can be made separately.