### PR TITLE
Use xenial dist in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
 cache: pip
 python:
-  - "3.6-dev"
+  - "3.6"
+  - "3.7"
   - "3.7-dev"
   - "nightly"
+dist: xenial
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
🍝 Reading this (https://docs.travis-ci.com/user/languages/python/#development-releases-support), trusty has outdated Python versions. Python3.7-dev in there was really Python 3.7.0a4 instead of the latest release.

With xenial, `3.7` gives us Python 3.7.1, and `3.7-dev` gives us Python 3.7.2+.