### PR TITLE
Graphql

### DIFF
--- a/gidgethub/routing.py
+++ b/gidgethub/routing.py
@@ -67,6 +67,10 @@ class Router:
         except KeyError:
             pass
         try:
+            found_callbacks.extend(self._shallow_routes['*'])
+        except KeyError:
+            pass
+        try:
             details = self._deep_routes[event.event]
         except KeyError:
             pass

--- a/gidgethub/sansio.py
+++ b/gidgethub/sansio.py
@@ -12,6 +12,7 @@ import hmac
 import http
 import json
 import re
+from string import Template
 from typing import Any, Dict, Mapping, Optional, Tuple, Type, Union
 import urllib.parse
 
@@ -340,3 +341,11 @@ def format_url(url: str, url_vars: Mapping[str, Any]) -> str:
     url = urllib.parse.urljoin(DOMAIN, url)  # Works even if 'url' is fully-qualified.
     expanded_url: str = uritemplate.expand(url, var_dict=url_vars)
     return expanded_url
+
+
+V4_DOMAIN = "https://api.github.com/graphql"
+
+
+def format_query(template: str, variables: Mapping[str, Any]) -> str:
+    """Format the GraphQL query template substituting the given mapping."""
+    return Template(template).safe_substitute(variables)


### PR DESCRIPTION
Here are a couple of things I've found useful as I'm using this framework for some of my own apps.

* Support wildcard event dispatch
* Add the [v4 GraphQL](https://developer.github.com/v4/) endpoint
* Add a `gidgethub.sansio.format_query()` function which uses [PEP 292](https://www.python.org/dev/peps/pep-0292/) style templates for formulate GraphQL queries.  Why PEP 292 instead of `.format()` or f-strings?  Yeah, well have fun escaping your GraphQL braces! :)

Here's an example GraphQL query call:

```
@router.register('pull_request_review')
@router.register('pull_request_review_comment')
async def check_comments_resolved(event, gh, *args, **kwargs):
    """Add a status block when there are unresolved review comments"""
    # Get the review comment thread for the PR being edited.
    event_data = ObjectifyJSON(event.data)
    pr_number = event_data.pull_request.number
    query = format_query("""
{
  repository(owner:"xxx", name:"yyy") {
    issueOrPullRequest(number:$pr_number) {
      ... on PullRequest {
        id
        reviewThreads(last:50) {
          nodes {
            id,
            isResolved
          }
        }
        commits(last: 1) {
          nodes {
            commit {
              oid
            }
          }
        }
      }
    }
  }
}
""", dict(pr_number=pr_number))
    json = await gh.post(sansio.V4_DOMAIN, data=dict(query=query), oauth_token=gh.oauth_token)
