### PR TITLE
Fix httpx support

### DIFF
--- a/gidgethub/httpx.py
+++ b/gidgethub/httpx.py
@@ -20,7 +20,7 @@ class GitHubAPI(gh_abc.GitHubAPI):
         """Make an HTTP request."""
         response = await self._client.request(
             method, url, headers=dict(headers), data=body)
-        return response.status_code, response.headers, await response.read()
+        return response.status_code, response.headers, response.content
 
     async def sleep(self, seconds: float) -> None:
         """Sleep for the specified number of seconds."""

--- a/gidgethub/httpx.py
+++ b/gidgethub/httpx.py
@@ -2,7 +2,7 @@ import asyncio
 from typing import Mapping, Tuple, Any
 
 try:
-    from httpx import AsyncClient as Client  # type: ignore
+    from httpx import AsyncClient as Client
 except ImportError:
     from httpx import Client
 


### PR DESCRIPTION
The `read()` method is gone, so use the simple `content` attribute instead.

Closes #92 