### PR TITLE
Fix the reference to the GitHubAPI.graphql documentation in the changelog

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 4.1.1
 -----
 
-- Fix func:`abc.GitHubAPI.graphql` to accept response content types lacking
+- Fix :meth:`gidgethub.abc.GitHubAPI.graphql` to accept response content types lacking
   spaces; affects GitHub Enterprise
   (`Issue #122 <https://github.com/brettcannon/gidgethub/pull/122>`_)
 


### PR DESCRIPTION

It was missing a colon at the front of `:func:`
I've changed it to :meth:`gidgethub.abc.GitHubAPI.graphql` to be consistent with what was written in the previous changelog entry (v4.0.0)

