### PR TITLE
Allow passing content-type header to GitHubAPI.POST

### DIFF
--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -171,7 +171,7 @@ experimental APIs without issue.
             :meth:`getitem`.
 
 
-    .. coroutine:: post(url, url_vars={}, *, data, accept=sansio.accept_format(), jwt=None, oauth_token=None)
+    .. coroutine:: post(url, url_vars={}, *, data, accept=sansio.accept_format(), jwt=None, oauth_token=None, content_type=None)
 
         Send a ``POST`` request to GitHub.
 
@@ -185,8 +185,19 @@ experimental APIs without issue.
         raised if both are passed. If neither was passed, it defaults to the
         value of the *oauth_token* attribute.
 
+        *content_type* is the value of the desired request header's content type.
+        If supplied, the data will be passed as the body in its raw format.
+        If not supplied, it will assume the default "application/json" content type,
+        and the data will be parsed as JSON.
+
         A few GitHub POST endpoints do not take any *data* argument, for example
-        the endpoint to `create an installation access token <https://developer.github.com/v3/apps/#create-a-github-app-from-a-manifest>`_. For this situation, you can pass ``data=b""``.
+        the endpoint to `create an installation access token <https://developer.github.com/v3/apps/#create-a-github-app-from-a-manifest>`_.
+        For this situation, you can pass ``data=b""``.
+
+
+        .. versionchanged:: 4.12
+            Added *content_type*.
+
 
         .. versionchanged:: 3.0
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+4.2.0
+-----
+
+- :meth:`gidgethub.abc.GitHubAPI.post` now accepts ``content_type`` parameter.
+  If supplied, the ``content_type`` value will be used in the request headers,
+  and the raw form of the data will be passed to the request. If not supplied,
+  by default the data will be parsed as JSON, and the "application/json" content
+  type will be used. (`Issue #115 <https://github.com/brettcannon/gidgethub/issues/115>`_).
+
+
 4.1.1
 -----
 

--- a/gidgethub/__init__.py
+++ b/gidgethub/__init__.py
@@ -1,5 +1,5 @@
 """An async GitHub API library"""
-__version__ = "4.1.1"
+__version__ = "4.2.0"
 
 import http
 from typing import Any, Optional

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -387,6 +387,15 @@ class TestGitHubAPIPost:
 
         assert str(exc_info.value) == "Cannot pass both oauth_token and jwt."
 
+    @pytest.mark.asyncio
+    async def test_with_passed_content_type(self):
+        """Assert that the body is not parsed to JSON and the content-type header is set."""
+        gh = MockGitHubAPI()
+        await gh.post("/fake", data="blabla", content_type="application/zip")
+        assert gh.method == "POST"
+        assert gh.headers["content-type"] == "application/zip"
+        assert gh.body == "blabla"
+
 
 class TestGitHubAPIPatch:
     @pytest.mark.asyncio
@@ -842,6 +851,6 @@ class TestGraphQL:
     @pytest.mark.asyncio
     async def test_no_response_data(self):
         # An empty response should raise an exception.
-        gh = MockGitHubAPI(200, body=b"", oauth_token="oauth-token",)
+        gh = MockGitHubAPI(200, body=b"", oauth_token="oauth-token")
         with pytest.raises(GraphQLException):
             await gh.graphql("does not matter")


### PR DESCRIPTION
When the content-type is passed, the raw body is used in the request.
The default content-type is json, and the body would be parsed to JSON format.

Updated documentation and changelog.

Closes https://github.com/brettcannon/gidgethub/issues/115

