### PR TITLE
Update docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Alternative libraries
 ---------------------
 
 If you think you want a different approach to the GitHub API,
-`GitHub maintains a list of libraries <https://developer.github.com/v3/libraries/>`_.
+`GitHub maintains a list of libraries <https://docs.github.com/en/free-pro-team@latest/rest/overview/libraries>`_.
 
 
 *Aside*: what's with the name?

--- a/docs/__init__.rst
+++ b/docs/__init__.rst
@@ -73,7 +73,7 @@ Exceptions
 .. exception:: InvalidField(errors, *args)
 
    Raised when a
-   `field in a request is invalid <https://developer.github.com/v3/#client-errors>`_.
+   `field in a request is invalid <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#client-errors>`_.
 
    Inherits from :exc:`BadRequest` and explicitly specifies a ``422`` status
    code. Details of what fields were invalid are stored in the :attr:`errors`

--- a/docs/__init__.rst
+++ b/docs/__init__.rst
@@ -15,7 +15,7 @@ Exceptions
 .. exception:: ValidationFailure
 
    An exception representing
-   `failed validation of a webhook event <https://developer.github.com/webhooks/securing/#validating-payloads-from-github>`_.
+   `failed validation of a webhook event <https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github>`_.
 
    Inherits from :exc:`GitHubException`.
 

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -41,7 +41,7 @@ experimental APIs without issue.
 
     There are common arguments across methods that make requests to
     GitHub. The *url_vars* argument is used to perform
-    `URI template expansion <https://developer.github.com/v3/#hypermedia>`_
+    `URI template expansion <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#hypermedia>`_
     via :func:`gidgethub.sansio.format_url`.The *accept* argument
     specifies what response format is acceptable and can be
     constructed by using :func:`gidgethub.sansio.accept_format`. For
@@ -59,7 +59,7 @@ experimental APIs without issue.
     .. versionchanged:: 2.0
         Methods no longer automatically sleep when there is a chance
         of exceeding the
-        `rate limit <https://developer.github.com/v3/#rate-limiting>`_.
+        `rate limit <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting>`_.
         This leads to :exc:`~gidgethub.RateLimitExceeded` being raised
         when the rate limit has been execeeded.
 
@@ -108,7 +108,7 @@ experimental APIs without issue.
         An abstract :term:`coroutine` which causes the coroutine to
         sleep for the specified number of seconds. This is provided to
         help prevent from going over one's
-        `rate limit <https://developer.github.com/v3/#rate-limiting>`_.
+        `rate limit <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting>`_.
 
         .. versionchanged:: 2.0
 
@@ -144,7 +144,7 @@ experimental APIs without issue.
 
         An asynchronous iterable is returned which will yield all items
         from the endpoint (i.e. use ``async for`` on the result). Any
-        `pagination <https://developer.github.com/v3/#pagination>`_
+        `pagination <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#pagination>`_
         will automatically be followed.
 
         *jwt* is the value of the JSON web token, for authenticating as a GitHub
@@ -191,7 +191,7 @@ experimental APIs without issue.
         and the data will be parsed as JSON.
 
         A few GitHub POST endpoints do not take any *data* argument, for example
-        the endpoint to `create an installation access token <https://developer.github.com/v3/apps/#create-a-github-app-from-a-manifest>`_.
+        the endpoint to `create an installation access token <https://docs.github.com/en/free-pro-team@latest/developers/apps/creating-a-github-app-from-a-manifest#implementing-the-github-app-manifest-flow>`_.
         For this situation, you can pass ``data=b""``.
 
 
@@ -228,7 +228,7 @@ experimental APIs without issue.
         Send a ``PUT`` request to GitHub.
 
         Be aware that some ``PUT`` endpoints such as
-        `locking an issue <https://developer.github.com/v3/issues/#lock-an-issue>`_
+        `locking an issue <https://docs.github.com/en/free-pro-team@latest/rest/reference/issues#lock-an-issue>`_
         will return no content, leading to ``None`` being returned.
 
         *jwt* is the value of the JSON web token, for authenticating as a GitHub
@@ -270,13 +270,13 @@ experimental APIs without issue.
 
     .. coroutine:: graphql(query, *, endpoint="https://api.github.com/graphql", **variables)
 
-       Make a request of the `GraphQL v4 API <https://developer.github.com/v4/>`_.
+       Make a request of the `GraphQL v4 API <https://docs.github.com/en/free-pro-team@latest/graphql>`_.
 
        The *endpoint* argument specifies the
-       `root endpoint <https://developer.github.com/v4/guides/forming-calls/#the-graphql-endpoint>`_
+       `root endpoint <https://docs.github.com/en/free-pro-team@latest/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint>`_
        to use for the GraphQL request.
        The *variables* argument collects all other keyword arguments to pass in
-       `variables <https://developer.github.com/v4/guides/forming-calls/#working-with-variables>`_
+       `variables <https://docs.github.com/en/free-pro-team@latest/graphql/guides/forming-calls-with-graphql#working-with-variables>`_
        for the query.
 
        Exceptions raised directly by this method all subclass

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -32,7 +32,7 @@ experimental APIs without issue.
     OAuth token and a cache object.
 
     To allow for
-    `conditional requests <https://developer.github.com/v3/#conditional-requests>`_,
+    `conditional requests <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#conditional-requests>`_,
     one can provide a :class:`collections.abc.MutableMapping` object
     for the *cache* argument to cache requests. It is up to the
     caching object to provide any caching scheme that is desired

--- a/docs/apps.rst
+++ b/docs/apps.rst
@@ -5,7 +5,7 @@
 
 .. versionadded:: 4.1.0
 
-This module is to help provide support for `GitHub Apps <https://developer.github.com/v3/apps/>`_.
+This module is to help provide support for `GitHub Apps <https://docs.github.com/en/free-pro-team@latest/rest/reference/apps>`_.
 
 Example on how you would obtain the access token for authenticating as a GitHub App installation::
 
@@ -36,7 +36,7 @@ Example on how you would obtain the access token for authenticating as a GitHub 
     **private_key** is the content of the GitHub App's private key (``.PEM`` format) file.
 
     It returns the response from GitHub's
-    `Authenticating as an installation <https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation>`_ API endpoint.
+    `Authenticating as an installation <https://docs.github.com/en/free-pro-team@latest/developers/apps/authenticating-with-github-apps#authenticating-as-an-installation>`_ API endpoint.
 
 
 .. function:: get_jwt(*, app_id, private_key)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -83,7 +83,7 @@ Changelog
 -----
 
 - :meth:`gidgethub.abc.GitHubAPI.getiter` now works with
-  `GitHub's search API <https://developer.github.com/v3/search/>`_
+  `GitHub's search API <https://docs.github.com/en/free-pro-team@latest/rest/reference/search>`_
   (thanks `Pablo Galindo <https://github.com/pablogsal>`_).
 
 3.0.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ gidgethub --- An async library for calling GitHub's API
 =======================================================
 
 While there are many
-`GitHub libraries <https://developer.github.com/libraries/>`_ for
+`GitHub libraries <https://docs.github.com/en/free-pro-team@latest/rest/overview/libraries>`_ for
 Python, when this library was created there were none oriented towards
 asynchronous usage. On top of that, there were also no libraries which
 took a `sans-I/O approach <https://sans-io.readthedocs.io/>`_ to their

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -7,7 +7,7 @@
 
 When a single web service is used to perform multiple actions based on
 a single
-`webhook event <https://developer.github.com/webhooks/#events>`_, it
+`webhook event <https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/about-webhooks#events>`_, it
 is easier to do those multiple steps in some sort of routing mechanism
 to make sure the right objects are called is provided. This module is
 meant to provide such a router for :class:`gidgethub.sansio.Event`

--- a/docs/sansio.rst
+++ b/docs/sansio.rst
@@ -5,7 +5,7 @@
 
 Webhook events
 --------------
-`Webhook events <https://developer.github.com/webhooks/>`_ are represented by
+`Webhook events <https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/about-webhooks>`_ are represented by
 :class:`Event` objects. The expectation is that a server will receive an HTTP
 request from GitHub and then use :meth:`Event.from_http` to create an
 :class:`Event` instance. For example::
@@ -28,7 +28,7 @@ without requiring the use of the :class:`Event` class.
 
 .. function:: validate_event(payload, *, signature, secret)
 
-   `Validate the signature <https://developer.github.com/webhooks/securing/#validating-payloads-from-github>`_
+   `Validate the signature <https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github>`_
    of a webhook event.
 
    :exc:`~gidgethub.ValidationFailure` is raised if the signature is malformed
@@ -44,14 +44,14 @@ without requiring the use of the :class:`Event` class.
 
    .. attribute:: data
 
-      The `payload <https://developer.github.com/webhooks/event-payloads/>`_ of the
+      The `payload <https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads>`_ of the
       event.
 
 
    .. attribute:: event
 
       The string representation of the
-      `triggering event <https://developer.github.com/webhooks/#events>`_.
+      `triggering event <https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/about-webhooks#events>`_.
 
 
    .. attribute:: delivery_id
@@ -66,7 +66,7 @@ without requiring the use of the :class:`Event` class.
       The *headers* mapping is expected to support lowercase keys.
 
       Since this method assumes the body of the HTTP request is only of the
-      `content type that GitHub sends <https://developer.github.com/webhooks/creating/#content-type>`_,
+      `content type that GitHub sends <https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/creating-webhooks#content-type>`_,
       :exc:`~gidgethub.BadRequest` is raised if the content type is
       unexpected.
 
@@ -79,7 +79,7 @@ without requiring the use of the :class:`Event` class.
 Calling the GitHub API
 ----------------------
 As well as receiving webhook events in response to actions occurring on GitHub,
-you can use the `GitHub API <https://developer.github.com/v3/>`_ to make calls
+you can use the `GitHub API <https://docs.github.com/en/free-pro-team@latest/rest>`_ to make calls
 to REST endpoints. This library provides support to both construct a request to
 the GitHub API as well as deciphering the response to a request.
 
@@ -101,7 +101,7 @@ by helping to automate the GitHub-specific aspects of a REST call.
 
    Construct the specification of the format that a request should return. This
    is used in the ``accept`` header field of a request to specify the
-   `media type <https://developer.github.com/v3/media/>`_.
+   `media type <https://docs.github.com/en/free-pro-team@latest/rest/overview/media-types>`_.
 
    The *version* argument specifies what version of the GitHub API that the
    request applies to. Typically this only needs to be specified if you are
@@ -117,7 +117,7 @@ by helping to automate the GitHub-specific aspects of a REST call.
    to get a media type of ``application/vnd.github.v3.diff``.
 
    The default arguments of this function will always return the
-   `latest version <https://developer.github.com/v3/#current-version>`_ of the
+   `latest version <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#current-version>`_ of the
    GitHub API with the default response format that this library is designed to
    support.
 
@@ -127,7 +127,7 @@ by helping to automate the GitHub-specific aspects of a REST call.
    Create a dict representing GitHub-specific header fields.
 
    The user agent is set according to who the *requester* is.
-   `GitHub asks <https://developer.github.com/v3/#user-agent-required>`_ it be
+   `GitHub asks <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#user-agent-required>`_ it be
    either a username or project name.
 
    The *accept* argument corresponds to the ``'accept'`` field and defaults to
@@ -137,12 +137,12 @@ by helping to automate the GitHub-specific aspects of a REST call.
    response, e.g. wanting the rendered HTML of a Markdown file.
 
    The *oauth_token* allows making an
-   `authenticated request <https://developer.github.com/v3/#authentication>`_.
+   `authenticated request <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#authentication>`_.
    This can be important if you need the expanded rate limit provided by an
    authenticated request.
 
    The *jwt* allows making an authenticated request as a `GitHub App
-   <https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app>`_.
+   <https://docs.github.com/en/free-pro-team@latest/developers/apps/authenticating-with-github-apps#authenticating-as-a-github-app>`_.
    You can pass only one: *oauth_token* or *jwt*, but not both.
 
    ``ValueError`` will be raised if both *jwt* and *oauth_token* are supplied.
@@ -179,7 +179,7 @@ that are provided to you. Continuing from the example in the Requests_ section::
 
 .. class:: RateLimit(*, limit, remaining, reset_epoch)
 
-    The `rate limit <https://developer.github.com/v3/#rate-limiting>`_ imposed
+    The `rate limit <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting>`_ imposed
     upon the requester.
 
     The *reset_epoch* argument is expected to be UTC seconds from the epoch.
@@ -229,10 +229,10 @@ that are provided to you. Continuing from the example in the Requests_ section::
     based on what the response specified.
 
     The last item of the tuple is the URL where to request the
-    `next set of results <https://developer.github.com/v3/#pagination>`_.
+    `next set of results <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#pagination>`_.
     If there are no more results then ``None`` is returned. Do be aware
     that the URL
-    `can be a URI template <https://developer.github.com/v3/#link-header>`_
+    `can be a URI template <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#link-header>`_
     and so it may need to be expanded.
 
     If the status code is anything other than ``200``, ``201``, or ``204``,
@@ -251,7 +251,7 @@ Utilities
     from the GitHub developer documentation.
 
     The dict provided in *url_vars* is used in
-    `URI template expansion <https://developer.github.com/v3/#hypermedia>`_.
+    `URI template expansion <https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#hypermedia>`_.
     Appropriate URL quoting is automatically done on the values of the dict.
 
     Enterprise GitHub users can specify their custom base URL in *base_url*.

--- a/gidgethub/__init__.py
+++ b/gidgethub/__init__.py
@@ -14,7 +14,7 @@ class ValidationFailure(GitHubException):
 
     """An exception representing failed validation of a webhook event."""
 
-    # https://developer.github.com/webhooks/securing/#validating-payloads-from-github
+    # https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github
 
 
 class HTTPException(GitHubException):
@@ -40,7 +40,7 @@ class BadRequest(HTTPException):
     Used for 4XX HTTP errors.
     """
 
-    # https://developer.github.com/v3/#client-errors
+    # https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#client-errors
 
 
 class BadRequestUnknownError(BadRequest):

--- a/gidgethub/apps.py
+++ b/gidgethub/apps.py
@@ -24,7 +24,7 @@ async def get_installation_access_token(
 
 
     Return a dictionary containing access token and expiration time.
-    (https://developer.github.com/v3/apps/#create-a-new-installation-token)
+    (https://docs.github.com/en/free-pro-team@latest/rest/reference/apps#create-an-installation-access-token-for-an-app)
     """
     access_token_url = f"/app/installations/{installation_id}/access_tokens"
     token = get_jwt(app_id=app_id, private_key=private_key)

--- a/gidgethub/sansio.py
+++ b/gidgethub/sansio.py
@@ -69,7 +69,7 @@ def _decode_body(
 
 def validate_event(payload: bytes, *, signature: str, secret: str) -> None:
     """Validate the signature of a webhook event."""
-    # https://developer.github.com/webhooks/securing/#validating-payloads-from-github
+    # https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github
     signature_prefix = "sha1="
     if not signature.startswith(signature_prefix):
         raise ValidationFailure(
@@ -86,8 +86,8 @@ class Event:
     """Details of a GitHub webhook event."""
 
     def __init__(self, data: Any, *, event: str, delivery_id: str) -> None:
-        # https://developer.github.com/v3/activity/events/types/
-        # https://developer.github.com/webhooks/#delivery-headers
+        # https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads
+        # https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#delivery-headers
         self.data = data
         # Event is not an enum as GitHub provides the string. This allows them
         # to add new events without having to mirror them here. There's also no
@@ -151,8 +151,8 @@ def accept_format(
     version of the GitHub API in the default format that this library is
     designed to support.
     """
-    # https://developer.github.com/v3/media/
-    # https://developer.github.com/v3/#current-version
+    # https://docs.github.com/en/free-pro-team@latest/rest/overview/media-types
+    # https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#current-version
     accept = f"application/vnd.github.{version}"
     if media is not None:
         accept += f".{media}"
@@ -190,11 +190,11 @@ def create_headers(
 
     For consistency, all keys in the returned dict will be lowercased.
     """
-    # user-agent: https://developer.github.com/v3/#user-agent-required
-    # accept: https://developer.github.com/v3/#current-version
-    #         https://developer.github.com/v3/media/
-    # authorization: https://developer.github.com/v3/#authentication
-    # authenticating as a GitHub App: https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app
+    # user-agent: https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#user-agent-required
+    # accept: https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#current-version
+    #         https://docs.github.com/en/free-pro-team@latest/rest/overview/media-types
+    # authorization: https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#authentication
+    # authenticating as a GitHub App: https://docs.github.com/en/free-pro-team@latest/developers/apps/authenticating-with-github-apps#authenticating-as-a-github-app
 
     if oauth_token is not None and jwt is not None:
         raise ValueError("Cannot pass both oauth_token and jwt.")
@@ -225,7 +225,7 @@ class RateLimit:
     reset datetime has passed.
     """
 
-    # https://developer.github.com/v3/#rate-limiting
+    # https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting
 
     def __init__(self, *, limit: int, remaining: int, reset_epoch: float) -> None:
         """Instantiate a RateLimit object.
@@ -277,7 +277,7 @@ _link_re = re.compile(
 
 
 def _next_link(link: Optional[str]) -> Optional[str]:
-    # https://developer.github.com/v3/#pagination
+    # https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#pagination
     # https://tools.ietf.org/html/rfc5988
     if link is None:
         return None

--- a/tests/samples/GraphQL/bad-credentials-401.json
+++ b/tests/samples/GraphQL/bad-credentials-401.json
@@ -1,4 +1,4 @@
 {
     "message": "Bad credentials",
-    "documentation_url": "https://developer.github.com/v4"
+    "documentation_url": "https://docs.github.com/en/free-pro-team@latest/graphql"
 }

--- a/tests/samples/GraphQL/malformed-json-400.json
+++ b/tests/samples/GraphQL/malformed-json-400.json
@@ -1,4 +1,4 @@
 {
     "message": "Problems parsing JSON",
-    "documentation_url": "https://developer.github.com/v4"
+    "documentation_url": "https://docs.github.com/en/free-pro-team@latest/graphql"
 }

--- a/tests/samples/pr_not_found/body
+++ b/tests/samples/pr_not_found/body
@@ -1,4 +1,4 @@
 {
   "message": "Not Found",
-  "documentation_url": "https://developer.github.com/v3"
+  "documentation_url": "https://docs.github.com/en/free-pro-team@latest/rest"
 }

--- a/tests/samples/search_issues_page_last/body
+++ b/tests/samples/search_issues_page_last/body
@@ -55,7 +55,7 @@
       "updated_at": "2017-03-27T01:07:03Z",
       "closed_at": "2017-03-27T01:07:03Z",
       "author_association": "OWNER",
-      "body": "Detect a [403 response and `X-RateLimit-Remaining` is 0](https://developer.github.com/v3/#rate-limiting). This would allow users to do what they want when their rate limit is reached instead of gidgethub making that decision for them by sleeping. It also has the perk of simplifying gidgethub's own code. 😁 ",
+      "body": "Detect a [403 response and `X-RateLimit-Remaining` is 0](https://docs.github.com/en/free-pro-team@latest/rest/overview/resources-in-the-rest-api#rate-limiting). This would allow users to do what they want when their rate limit is reached instead of gidgethub making that decision for them by sleeping. It also has the perk of simplifying gidgethub's own code. 😁 ",
       "score": 0.04832509
     },
     {

--- a/tests/test_sansio.py
+++ b/tests/test_sansio.py
@@ -367,7 +367,7 @@ class TestDecipherResponse:
         body = json.dumps(
             {
                 "message": "Reference does not exist",
-                "documentation_url": "https://developer.github.com/v3/git/refs/#delete-a-reference",
+                "documentation_url": "https://docs.github.com/en/free-pro-team@latest/rest/reference/git#delete-a-reference",
             }
         )
         body = body.encode("utf-8")


### PR DESCRIPTION
GitHub moved their documentation from developer.github.com to docs.github.com, and it was building the ci-lint job.

I searched all occurrences of the old docs urls and replaced with the current ones.
