### PR TITLE
Specify that gidgethub requires PyJWT >= 2.0.0.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ Changelog
   (`Issue #74 <https://github.com/brettcannon/gidgethub/issues/74>`_).
 - Fix mypy errors in ``gidgethub.httpx.GitHubAPI._request``
   (`Issue #133 <https://github.com/brettcannon/gidgethub/issues/133>`_).
-- The minimum version of PyJWT to v 2.0.0.
+- Make the minimum version of PyJWT be v2.0.0.
 
 4.2.0
 -----

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Changelog
   (`Issue #74 <https://github.com/brettcannon/gidgethub/issues/74>`_).
 - Fix mypy errors in ``gidgethub.httpx.GitHubAPI._request``
   (`Issue #133 <https://github.com/brettcannon/gidgethub/issues/133>`_).
+- The minimum version of PyJWT to v 2.0.0.
 
 4.2.0
 -----

--- a/gidgethub/apps.py
+++ b/gidgethub/apps.py
@@ -11,8 +11,7 @@ def get_jwt(*, app_id: str, private_key: str) -> str:
     """Construct the JWT (JSON Web Token), used for GitHub App authentication."""
     time_int = int(time.time())
     payload = {"iat": time_int, "exp": time_int + (10 * 60), "iss": app_id}
-    encoded = jwt.encode(payload, private_key, algorithm="RS256")
-    bearer_token = encoded.decode("utf-8")
+    bearer_token = jwt.encode(payload, private_key, algorithm="RS256")
 
     return bearer_token
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ author = "Brett Cannon"
 author-email = "brett@python.org"
 requires = [
     "uritemplate>=3.0.1",
-    "PyJWT[crypto]"
+    "PyJWT[crypto]>=2.0.0"
 ]
 requires-python = ">=3.6"
 license = "Apache"

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -30,9 +30,7 @@ class TestGitHubAppUtils:
             "iss": app_id,
         }
 
-        assert result == jwt.encode(
-            expected_payload, private_key, algorithm="RS256"
-        ).decode("utf-8")
+        assert result == jwt.encode(expected_payload, private_key, algorithm="RS256")
 
     @pytest.mark.asyncio
     async def test_get_installation_access_token(self):


### PR DESCRIPTION
v 5.0.0 is not released yet, so we can bundle this in.