### PR TITLE
Remove the preview header from get_installation_access_token

### DIFF
--- a/docs/apps.rst
+++ b/docs/apps.rst
@@ -5,6 +5,9 @@
 
 .. versionadded:: 4.1.0
 
+.. versionchanged:: 5.0.1
+   The ``machine-man-preview`` header was removed from the API endpoint.
+
 This module is to help provide support for `GitHub Apps <https://docs.github.com/en/free-pro-team@latest/rest/reference/apps>`_.
 
 Example on how you would obtain the access token for authenticating as a GitHub App installation::

--- a/docs/apps.rst
+++ b/docs/apps.rst
@@ -61,5 +61,4 @@ Example on how you would obtain the access token for authenticating as a GitHub 
        data = gh.getitem(
            "/app/installations",
            jwt=token,
-           accept="application/vnd.github.machine-man-preview+json",
        )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+5.0.1 (in development)
+----------------------
+
+- Drop the ``machine-man-preview`` header from :meth:`gidgethub.apps.get_installation_access_token`
+  because it is out of preview. The ``machine-man-preview`` is `no longer
+  required <https://developer.github.com/changes/#--machine-man-and-sailor-v-previews-graduate>`_
+  as of August 20, 2020.
+
+
 5.0.0
 -----
 

--- a/gidgethub/apps.py
+++ b/gidgethub/apps.py
@@ -31,7 +31,6 @@ async def get_installation_access_token(
         access_token_url,
         data=b"",
         jwt=token,
-        accept="application/vnd.github.machine-man-preview+json",
     )
     # example response
     # {


### PR DESCRIPTION
Address the issue brought up in https://github.com/brettcannon/gidgethub/discussions/155.

I removed the ``accept`` header from the API call. gidgethub puts in the default header already, so we don't have to pass in anything.
