### PR TITLE
Use X-Hub-Signature-256 for webhook validation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,9 @@ Changelog
 5.0.1.dev (under development)
 -----------------------------
 
+- Use ``X-Hub-Signature-256`` header for webhook validation when available.
+  (`PR #160 <https://github.com/brettcannon/gidgethub/pull/160>`_).
+
 5.0.1
 -----
 

--- a/gidgethub/sansio.py
+++ b/gidgethub/sansio.py
@@ -69,16 +69,25 @@ def _decode_body(
 
 def validate_event(payload: bytes, *, signature: str, secret: str) -> None:
     """Validate the signature of a webhook event."""
-    # https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github
-    signature_prefix = "sha256="
-    if not signature.startswith(signature_prefix):
+    # https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github
+    sha256_signature_prefix = "sha256="
+    sha1_signature_prefix = "sha1="
+    if signature.startswith(sha256_signature_prefix):
+        hmac_sig = hmac.new(
+            secret.encode("UTF-8"), msg=payload, digestmod="sha256"
+        ).hexdigest()
+        calculated_sig = sha256_signature_prefix + hmac_sig
+    elif signature.startswith(sha1_signature_prefix):
+        hmac_sig = hmac.new(
+            secret.encode("UTF-8"), msg=payload, digestmod="sha1"
+        ).hexdigest()
+        calculated_sig = sha1_signature_prefix + hmac_sig
+    else:
         raise ValidationFailure(
-            "signature does not start with " f"{repr(signature_prefix)}"
+            f"signature does not start with {repr(sha256_signature_prefix)} or {repr(sha1_signature_prefix)}"
         )
-    hmac_ = hmac.new(secret.encode("UTF-8"), msg=payload, digestmod="sha256")
-    calculated_sig = signature_prefix + hmac_.hexdigest()
     if not hmac.compare_digest(signature, calculated_sig):
-        raise ValidationFailure("payload's signature does not align " "with the secret")
+        raise ValidationFailure("payload's signature does not align with the secret")
 
 
 class Event:
@@ -114,12 +123,11 @@ class Event:
         (including not providing a secret) will lead to ValidationFailure being
         raised.
         """
-        if "x-hub-signature-256" in headers:
+        signature = headers.get("x-hub-signature-256", headers.get("x-hub-signature"))
+        if signature is not None:
             if secret is None:
                 raise ValidationFailure("secret not provided")
-            validate_event(
-                body, signature=headers["x-hub-signature-256"], secret=secret
-            )
+            validate_event(body, signature=signature, secret=secret)
         elif secret is not None:
             raise ValidationFailure("signature is missing")
 

--- a/tests/test_sansio.py
+++ b/tests/test_sansio.py
@@ -26,8 +26,8 @@ class TestValidateEvent:
 
     secret = "123456"
     payload = "gidget".encode("UTF-8")
-    hash_signature = "8acc2ae97633ec018f118577f4872e103f24ef58"
-    signature = "sha1=" + hash_signature
+    hash_signature = "091319196718d5bcb1c20ad25fc890597423ecdbad1f947f560afd643b5000de"
+    signature = "sha256=" + hash_signature
 
     def test_malformed_signature(self):
         """Error out if the signature doesn't start with "sha1="."""
@@ -60,7 +60,7 @@ class TestEvent:
         "content-type": "application/json",
         "x-github-event": "pull_request",
         "x-github-delivery": "72d3162e-cc78-11e3-81ab-4c9367dc0958",
-        "x-hub-signature": "sha1=c28e33b2e56e548956c446e890929a6cbec3ac89",
+        "x-hub-signature-256": "sha256=0340d06469a1b35662ebd7a67ea2c0c328239f319f1cfafb221451de629e0430",
     }
 
     def check_event(self, event):
@@ -116,7 +116,7 @@ class TestEvent:
     def test_from_http_missing_signature(self):
         """Secret but no signature raises ValidationFailure."""
         headers_no_sig = self.headers.copy()
-        del headers_no_sig["x-hub-signature"]
+        del headers_no_sig["x-hub-signature-256"]
         with pytest.raises(ValidationFailure):
             sansio.Event.from_http(headers_no_sig, self.data_bytes, secret=self.secret)
 
@@ -128,7 +128,7 @@ class TestEvent:
 
     def test_from_http_no_signature(self):
         headers = self.headers.copy()
-        del headers["x-hub-signature"]
+        del headers["x-hub-signature-256"]
         event = sansio.Event.from_http(headers, self.data_bytes)
         self.check_event(event)
 


### PR DESCRIPTION
As github recommends here: https://docs.github.com/en/developers/webhooks-and-events/securing-your-webhooks#validating-payloads-from-github