### PR TITLE
Bump min PyJWT v2.4.0

### DIFF
--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -244,7 +244,7 @@ experimental APIs without issue.
         Send a ``PUT`` request to GitHub.
 
         Be aware that some ``PUT`` endpoints such as
-        `locking an issue <https://docs.github.com/en/free-pro-team@latest/rest/reference/issues#lock-an-issue>`_
+        `locking an issue <https://docs.github.com/en/rest/issues/issues#lock-an-issue>`_
         will return no content, leading to ``None`` being returned.
 
         *jwt* is the value of the JSON web token, for authenticating as a GitHub

--- a/docs/apps.rst
+++ b/docs/apps.rst
@@ -8,7 +8,7 @@
 .. versionchanged:: 5.0.1
    The ``machine-man-preview`` header was removed from the API endpoint.
 
-This module is to help provide support for `GitHub Apps <https://docs.github.com/en/free-pro-team@latest/rest/reference/apps>`_.
+This module is to help provide support for `GitHub Apps <https://docs.github.com/en/rest/apps>`_.
 
 Example on how you would obtain the access token for authenticating as a GitHub App installation::
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -109,7 +109,7 @@ Changelog
 -----
 
 - :meth:`gidgethub.abc.GitHubAPI.getiter` now works with
-  `GitHub's search API <https://docs.github.com/en/free-pro-team@latest/rest/reference/search>`_
+  `GitHub's search API <https://docs.github.com/en/rest/search>`_
   (thanks `Pablo Galindo <https://github.com/pablogsal>`_).
 
 3.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ author = "Brett Cannon"
 author-email = "brett@python.org"
 requires = [
     "uritemplate>=3.0.1",
-    "PyJWT[crypto]>=2.0.0"
+    "PyJWT[crypto]>=2.4.0"
 ]
 requires-python = ">=3.6"
 license = "Apache"


### PR DESCRIPTION
There was a security advisory on PyJWT package: https://github.com/jpadilla/pyjwt/security/advisories/GHSA-ffqj-6fqr-9h24

I think it's best to require a minimum version of v2.4.0
