### PR TITLE
Add support for Python 3.11 and drop EOL Python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,14 +16,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.9-dev", "3.10", "3.10-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.10-dev", "3.11-dev"]
         include:
           - { python-version: "3.7", nox-python-version: "3.7" }
           - { python-version: "3.8", nox-python-version: "3.8" }
           - { python-version: "3.9", nox-python-version: "3.9" }
-          - { python-version: "3.9-dev", nox-python-version: "3.9" }
           - { python-version: "3.10", nox-python-version: "3.10" }
           - { python-version: "3.10-dev", nox-python-version: "3.10" }
+          - { python-version: "3.11-dev", nox-python-version: "3.11" }
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,9 @@ name: CI
 on:
   pull_request:
   push:
-    branches: main
+
+env:
+  FORCE_COLOR: 1
 
 jobs:
   test:
@@ -12,18 +14,27 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.9-dev", "3.10-dev"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.9-dev", "3.10", "3.10-dev"]
+        include:
+          - { python-version: "3.6", nox-python-version: "3.6" }
+          - { python-version: "3.7", nox-python-version: "3.7" }
+          - { python-version: "3.8", nox-python-version: "3.8" }
+          - { python-version: "3.9", nox-python-version: "3.9" }
+          - { python-version: "3.9-dev", nox-python-version: "3.9" }
+          - { python-version: "3.10", nox-python-version: "3.10" }
+          - { python-version: "3.10-dev", nox-python-version: "3.10" }
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         if: "!endsWith(matrix.python-version, '-dev')"
         with:
           python-version: ${{ matrix.python-version }}
@@ -32,10 +43,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install nox
-      - run: nox --session tests-${{ matrix.python-version }}
+      - run: nox --session tests-${{ matrix.nox-python-version }}
         env:
           PYTHONDEVMODE: 1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -45,15 +56,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - run: pip install nox
       - run: nox --session lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.9-dev", "3.10", "3.10-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.9-dev", "3.10", "3.10-dev"]
         include:
-          - { python-version: "3.6", nox-python-version: "3.6" }
           - { python-version: "3.7", nox-python-version: "3.7" }
           - { python-version: "3.8", nox-python-version: "3.8" }
           - { python-version: "3.9", nox-python-version: "3.9" }

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Gidgethub is `available on PyPI <https://pypi.org/project/gidgethub/>`_.
   python3 -m pip install gidgethub
 
 
-Gidgethub requires Python version 3.6 and up.
+Gidgethub requires Python version 3.7 and up.
 
 
 Goals

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # gidgethub documentation build configuration file, created by
 # sphinx-quickstart on Mon Jan 23 19:03:20 2017.

--- a/gidgethub/actions.py
+++ b/gidgethub/actions.py
@@ -15,7 +15,7 @@ def workspace() -> pathlib.Path:
 @functools.lru_cache(maxsize=1)
 def event() -> Any:
     """Return the webhook event data for the running action."""
-    with open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8") as file:
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as file:
         return json.load(file)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ def install_flit_dev_deps(session):
     session.run("flit", "install", "--deps", "develop")
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 def tests(session):
     install_flit_dev_deps(session)
     session.run("pytest", "--cov=gidgethub", "--cov-report=xml", "-n=auto", "tests")

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,10 +3,22 @@ import nox
 
 def install_flit_dev_deps(session):
     session.install("flit")
-    session.run("flit", "install", "--deps", "develop")
+    # TEMP for 3.11
+    if session.python == "3.11":
+        env = {
+            # https://github.com/aio-libs/aiohttp/issues/6600
+            "AIOHTTP_NO_EXTENSIONS": "1",
+            # https://github.com/aio-libs/frozenlist/issues/285
+            "FROZENLIST_NO_EXTENSIONS": "1",
+            # https://github.com/aio-libs/yarl/issues/680
+            "YARL_NO_EXTENSIONS": "1",
+        }
+    else:
+        env = {}
+    session.run("flit", "install", "--deps", "develop", env=env)
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
 def tests(session):
     install_flit_dev_deps(session)
     session.run("pytest", "--cov=gidgethub", "--cov-report=xml", "-n=auto", "tests")

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ def install_flit_dev_deps(session):
     session.run("flit", "install", "--deps", "develop")
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.9-dev", "3.10-dev"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
 def tests(session):
     install_flit_dev_deps(session)
     session.run("pytest", "--cov=gidgethub", "--cov-report=xml", "-n=auto", "tests")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
     "uritemplate>=3.0.1",
     "PyJWT[crypto]>=2.4.0"
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 license = "Apache"
 keywords = "github sans-io async"
 description-file = "README.rst"
@@ -18,7 +18,6 @@ classifiers = ["Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = ["Intended Audience :: Developers",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ classifiers = ["Intended Audience :: Developers",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8"
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
 ]
 
 [tool.flit.metadata.requires-extra]

--- a/tests/test_sansio.py
+++ b/tests/test_sansio.py
@@ -25,7 +25,7 @@ class TestValidateEvent:
     """Tests for gidgethub.sansio.validate_event()."""
 
     secret = "123456"
-    payload = "gidget".encode("UTF-8")
+    payload = b"gidget"
     hash_signature = "091319196718d5bcb1c20ad25fc890597423ecdbad1f947f560afd643b5000de"
     signature = "sha256=" + hash_signature
 
@@ -54,7 +54,7 @@ class TestEvent:
     """Tests for gidgethub.sansio.Event."""
 
     data = {"action": "opened"}
-    data_bytes = '{"action": "opened"}'.encode("UTF-8")
+    data_bytes = b'{"action": "opened"}'
     secret = "123456"
     headers = {
         "content-type": "application/json",


### PR DESCRIPTION
Includes PR #183 to fix CI.

3.11 needs some temporary workarounds to install dependencies, similar to Bedevere, see:

* https://github.com/python/bedevere/pull/399/files
* https://github.com/python/bedevere/pull/399#issuecomment-1073355585