### PR TITLE
Fix cgi and importlib_resources deprecations

### DIFF
--- a/gidgethub/sansio.py
+++ b/gidgethub/sansio.py
@@ -5,8 +5,8 @@ use any HTTP library you prefer while not having to implement common details
 when working with GitHub's API (e.g. validating webhook events or specifying the
 API version you want your request to work against).
 """
-import cgi
 import datetime
+from email.message import Message
 import hmac
 import http
 import json
@@ -40,8 +40,10 @@ def _parse_content_type(content_type: Optional[str]) -> Tuple[Optional[str], str
     if not content_type:
         return None, "utf-8"
     else:
-        type_, parameters = cgi.parse_header(content_type)
-        encoding = parameters.get("charset", "utf-8")
+        m = Message()
+        m["content-type"] = content_type
+        type_ = m.get_content_type()
+        encoding = m.get_param("charset") or "utf-8"
         return type_, encoding
 
 

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -702,7 +702,9 @@ class TestGraphQL:
     """Test gidgethub.abc.GitHubAPI.graphql()."""
 
     def gh_and_response(self, payload_filename):
-        payload = importlib_resources.read_binary(graphql_samples, payload_filename)
+        payload = (
+            importlib_resources.files(graphql_samples) / payload_filename
+        ).read_bytes()
         status_code_match = re.match(r"^.+-(\d+)\.json$", payload_filename)
         status_code = int(status_code_match.group(1))
         return (

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -21,7 +21,9 @@ class TestGitHubAppUtils:
         time_mock.return_value = 1587069751.5588422
 
         # test file copied from https://github.com/jpadilla/pyjwt/blob/master/tests/keys/testkey_rsa
-        private_key = importlib_resources.read_binary(rsa_key_samples, "test_rsa_key")
+        private_key = (
+            importlib_resources.files(rsa_key_samples) / "test_rsa_key"
+        ).read_bytes()
 
         result = apps.get_jwt(app_id=app_id, private_key=private_key)
         expected_payload = {
@@ -38,7 +40,9 @@ class TestGitHubAppUtils:
         installation_id = 6789
         app_id = 12345
 
-        private_key = importlib_resources.read_binary(rsa_key_samples, "test_rsa_key")
+        private_key = (
+            importlib_resources.files(rsa_key_samples) / "test_rsa_key"
+        ).read_bytes()
 
         await apps.get_installation_access_token(
             gh, installation_id=installation_id, app_id=app_id, private_key=private_key


### PR DESCRIPTION
```
gidgethub/sansio.py:8: 10 warnings
  /private/tmp/gidgethub/gidgethub/sansio.py:8: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi
```

Fix using `email` module as suggested at https://peps.python.org/pep-0594/#cgi

---


```
tests/test_abc.py: 10 warnings
  /private/tmp/gidgethub/tests/test_abc.py:705: DeprecationWarning: read_binary is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    payload = importlib_resources.read_binary(graphql_samples, payload_filename)

tests/test_apps.py::TestGitHubAppUtils::test_get_jwt
  /private/tmp/gidgethub/tests/test_apps.py:24: DeprecationWarning: read_binary is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    private_key = importlib_resources.read_binary(rsa_key_samples, "test_rsa_key")

tests/test_apps.py::TestGitHubAppUtils::test_get_installation_access_token
  /private/tmp/gidgethub/tests/test_apps.py:41: DeprecationWarning: read_binary is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    private_key = importlib_resources.read_binary(rsa_key_samples, "test_rsa_key")
```

Fix using `files()` API as suggested at https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy

