### PR TITLE
Add extra_headers option to get methods

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,8 +9,11 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
-# Optionally set the version of Python and requirements required to build your docs
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-   version: 3.11
    install:
-   - requirements: docs_requirements.txt
+      - requirements: docs_requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,6 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
+   version: 3.11
    install:
    - requirements: docs_requirements.txt

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -48,7 +48,9 @@ experimental APIs without issue.
     methods that send data to GitHub, there is a *data* argument which
     accepts an object which can be serialized to JSON (because
     ``None`` is a legitimate JSON value, ``""`` is used to represent
-    no data).
+    no data). The *extra_headers* argument optionally is ``dict[str, str]``,
+    and allows passing extra headers to the request specifying extra
+    options that the GitHub API allows.
 
     The returned value for GitHub requests is the decoded body of the
     response according to :func:`gidgethub.sansio.decipher_response`.
@@ -119,7 +121,7 @@ experimental APIs without issue.
             Renamed from ``_sleep()``.
 
 
-    .. py:method:: getitem(url, url_vars={}, *, accept=sansio.accept_format(), jwt=None, oauth_token=None)
+    .. py:method:: getitem(url, url_vars={}, *, accept=sansio.accept_format(), jwt=None, oauth_token=None, extra_headers=None)
         :async:
 
         Get a single item from GitHub.
@@ -162,7 +164,7 @@ experimental APIs without issue.
             on API endpoints like /orgs/{org}/members/{username} where the
             HTTP response code is the relevant answer.
 
-    .. py:method:: getiter(url, url_vars={}, *, accept=sansio.accept_format(), jwt=None, oauth_token=None, iterable_key="items")
+    .. py:method:: getiter(url, url_vars={}, *, accept=sansio.accept_format(), jwt=None, oauth_token=None, iterable_key="items", , extra_headers=None)
         :async:
 
         Get all items from a GitHub API endpoint.
@@ -203,7 +205,7 @@ experimental APIs without issue.
             :meth:`getitem`.
 
 
-    .. py:method:: post(url, url_vars={}, *, data, accept=sansio.accept_format(), jwt=None, oauth_token=None, content_type="application/json")
+    .. py:method:: post(url, url_vars={}, *, data, accept=sansio.accept_format(), jwt=None, oauth_token=None, content_type="application/json", extra_headers=None)
         :async:
 
         Send a ``POST`` request to GitHub.
@@ -237,7 +239,7 @@ experimental APIs without issue.
             Added *jwt* and *oauth_token*.
 
 
-    .. py:method:: patch(url, url_vars={}, *, data, accept=sansio.accept_format(), jwt=None, oauth_token=None)
+    .. py:method:: patch(url, url_vars={}, *, data, accept=sansio.accept_format(), jwt=None, oauth_token=None, extra_headers=None)
         :async:
 
         Send a ``PATCH`` request to GitHub.
@@ -257,7 +259,7 @@ experimental APIs without issue.
             Added *jwt* and *oauth_token*.
 
 
-    .. py:method:: put(url, url_vars={}, *, data=b"", accept=sansio.accept_format(), jwt=None, oauth_token=None)
+    .. py:method:: put(url, url_vars={}, *, data=b"", accept=sansio.accept_format(), jwt=None, oauth_token=None, extra_headers=None)
         :async:
 
         Send a ``PUT`` request to GitHub.
@@ -281,7 +283,7 @@ experimental APIs without issue.
             Added *jwt* and *oauth_token*.
 
 
-    .. py:method:: delete(url, url_vars={}, *, data=b"", accept=sansio.accept_format(), jwt=None, oauth_token=None)
+    .. py:method:: delete(url, url_vars={}, *, data=b"", accept=sansio.accept_format(), jwt=None, oauth_token=None, extra_headers=None)
         :async:
 
         Send a ``DELETE`` request to GitHub.

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -164,7 +164,7 @@ experimental APIs without issue.
             on API endpoints like /orgs/{org}/members/{username} where the
             HTTP response code is the relevant answer.
 
-    .. py:method:: getiter(url, url_vars={}, *, accept=sansio.accept_format(), jwt=None, oauth_token=None, iterable_key="items", , extra_headers=None)
+    .. py:method:: getiter(url, url_vars={}, *, accept=sansio.accept_format(), jwt=None, oauth_token=None, iterable_key="items", extra_headers=None)
         :async:
 
         Get all items from a GitHub API endpoint.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- Add extra_headers option to HTTP methods in GitHubAPI
+  (`Issue #193 <https://github.com/brettcannon/gidgethub/pull/193>_`)
+
+- Add support passing ``extra_headers`` when making requests
+  (`PR #192 <https://github.com/brettcannon/gidgethub/pull/192>_`)
+
 5.2.1
 -----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,7 +172,9 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/3/": None}
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+}
 
 
 html_sidebars = {

--- a/gidgethub/abc.py
+++ b/gidgethub/abc.py
@@ -65,6 +65,7 @@ class GitHubAPI(abc.ABC):
         jwt: Opt[str] = None,
         oauth_token: Opt[str] = None,
         content_type: str = JSON_CONTENT_TYPE,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> Tuple[bytes, Opt[str]]:
         """Construct and make an HTTP request."""
         if oauth_token is not None and jwt is not None:
@@ -83,6 +84,8 @@ class GitHubAPI(abc.ABC):
             request_headers = sansio.create_headers(
                 self.requester, accept=accept, oauth_token=self.oauth_token
             )
+        if extra_headers is not None:
+            request_headers.update(extra_headers)
         cached = cacheable = False
         # Can't use None as a "no body" sentinel as it's a legitimate JSON type.
         if data == b"":
@@ -130,11 +133,19 @@ class GitHubAPI(abc.ABC):
         accept: str = sansio.accept_format(),
         jwt: Opt[str] = None,
         oauth_token: Opt[str] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> Any:
         """Send a GET request for a single item to the specified endpoint."""
 
         data, _ = await self._make_request(
-            "GET", url, url_vars, b"", accept, jwt=jwt, oauth_token=oauth_token
+            "GET",
+            url,
+            url_vars,
+            b"",
+            accept,
+            jwt=jwt,
+            oauth_token=oauth_token,
+            extra_headers=extra_headers,
         )
         return data
 
@@ -146,11 +157,19 @@ class GitHubAPI(abc.ABC):
         accept: str = sansio.accept_format(),
         jwt: Opt[str] = None,
         oauth_token: Opt[str] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
         iterable_key: Opt[str] = ITERABLE_KEY,
     ) -> AsyncGenerator[Any, None]:
         """Return an async iterable for all the items at a specified endpoint."""
         data, more = await self._make_request(
-            "GET", url, url_vars, b"", accept, jwt=jwt, oauth_token=oauth_token
+            "GET",
+            url,
+            url_vars,
+            b"",
+            accept,
+            jwt=jwt,
+            oauth_token=oauth_token,
+            extra_headers=extra_headers,
         )
 
         if isinstance(data, dict) and iterable_key in data:
@@ -178,6 +197,7 @@ class GitHubAPI(abc.ABC):
         accept: str = sansio.accept_format(),
         jwt: Opt[str] = None,
         oauth_token: Opt[str] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
         content_type: str = JSON_CONTENT_TYPE,
     ) -> Any:
         data, _ = await self._make_request(
@@ -189,6 +209,7 @@ class GitHubAPI(abc.ABC):
             jwt=jwt,
             oauth_token=oauth_token,
             content_type=content_type,
+            extra_headers=extra_headers,
         )
         return data
 
@@ -201,9 +222,17 @@ class GitHubAPI(abc.ABC):
         accept: str = sansio.accept_format(),
         jwt: Opt[str] = None,
         oauth_token: Opt[str] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> Any:
         data, _ = await self._make_request(
-            "PATCH", url, url_vars, data, accept, jwt=jwt, oauth_token=oauth_token
+            "PATCH",
+            url,
+            url_vars,
+            data,
+            accept,
+            jwt=jwt,
+            oauth_token=oauth_token,
+            extra_headers=extra_headers,
         )
         return data
 
@@ -216,9 +245,17 @@ class GitHubAPI(abc.ABC):
         accept: str = sansio.accept_format(),
         jwt: Opt[str] = None,
         oauth_token: Opt[str] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> Any:
         data, _ = await self._make_request(
-            "PUT", url, url_vars, data, accept, jwt=jwt, oauth_token=oauth_token
+            "PUT",
+            url,
+            url_vars,
+            data,
+            accept,
+            jwt=jwt,
+            oauth_token=oauth_token,
+            extra_headers=extra_headers,
         )
         return data
 
@@ -231,9 +268,17 @@ class GitHubAPI(abc.ABC):
         accept: str = sansio.accept_format(),
         jwt: Opt[str] = None,
         oauth_token: Opt[str] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
     ) -> None:
         await self._make_request(
-            "DELETE", url, url_vars, data, accept, jwt=jwt, oauth_token=oauth_token
+            "DELETE",
+            url,
+            url_vars,
+            data,
+            accept,
+            jwt=jwt,
+            oauth_token=oauth_token,
+            extra_headers=extra_headers,
         )
 
     async def graphql(

--- a/gidgethub/abc.py
+++ b/gidgethub/abc.py
@@ -185,6 +185,7 @@ class GitHubAPI(abc.ABC):
                 jwt=jwt,
                 oauth_token=oauth_token,
                 iterable_key=iterable_key,
+                extra_headers=extra_headers,
             ):
                 yield item  # pragma: nocover
 


### PR DESCRIPTION
This allows to do for example:

```python
async def get_stargazers_with_dates(full_repo_name):
    headers = {"Accept": "application/vnd.github.v3.star+json"}
    async with httpx.AsyncClient() as client:
        gh = gidgethub.httpx.GitHubAPI(client, "basnijholt", oauth_token=token)
        repo_owner, repo_name = full_repo_name.split("/")
        stats_contributors = await gh.getitem(
            f"/repos/{repo_owner}/{repo_name}/stargazers", extra_headers=headers
        )
        return stats_contributors

await get_stargazers_with_dates("basnijholt/adaptive-lighting")
```

Some more extra headers folks might want to use:

https://github.com/PyGithub/PyGithub/blob/300c5015d41236eb410b9cbe895258294e3500af/github/Consts.py#L58-L133

Closes #193 