### PR TITLE
Add a getstatus() method to gidget.abc

### DIFF
--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -142,6 +142,25 @@ experimental APIs without issue.
             For ``GET`` calls that can return multiple values and
             potentially require pagination, see ``getiter()``.
 
+    .. py:method:: getstatus(url, url_vars={}, *, accept=sansio.accept_format(), jwt=None, oauth_token=None)
+        :async:
+
+        Get a single item's *HTTP status* from GitHub.
+
+        *jwt* is the value of the JSON web token, for authenticating as a GitHub
+        App.
+
+        *oauth_token* is the value of the oauth token, for making an authenticated
+        API call.
+
+        Only one of *oauth_token* or *jwt* may be passed. A ``ValueError`` is
+        raised if both are passed. If neither was passed, it defaults to the
+        value of the *oauth_token* attribute.
+
+        .. note::
+            This method discards any returned content, and is only for use
+            on API endpoints like /orgs/{org}/members/{username} where the
+            HTTP response code is the relevant answer.
 
     .. py:method:: getiter(url, url_vars={}, *, accept=sansio.accept_format(), jwt=None, oauth_token=None, iterable_key="items")
         :async:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,14 +1,11 @@
 Changelog
 =========
 
-5.2.2
+5.3.0
 -----
 
 - Add a getstatus() method for APIs that do not return content.
   (`PR #194 <https://github.com/brettcannon/gidgethub/pull/194>_`)
-
-- Update the interspinx mapping to 1.0-style.
-  (`PR #195 <https://github.com/brettcannon/gidgethub/pull/195>_`)
 
 5.2.1
 -----

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+5.2.2
+-----
+
+- Add a getstatus() method for APIs that do not return content.
+  (`PR #194 <https://github.com/brettcannon/gidgethub/pull/194>_`)
+
+- Update the interspinx mapping to 1.0-style.
+  (`PR #195 <https://github.com/brettcannon/gidgethub/pull/195>_`)
+
 5.2.1
 -----
 

--- a/gidgethub/__init__.py
+++ b/gidgethub/__init__.py
@@ -1,5 +1,5 @@
 """An async GitHub API library"""
-__version__ = "5.2.1"
+__version__ = "5.2.2"
 
 import http
 from typing import Any, Optional

--- a/gidgethub/__init__.py
+++ b/gidgethub/__init__.py
@@ -1,5 +1,5 @@
 """An async GitHub API library"""
-__version__ = "5.2.2"
+__version__ = "5.3.0"
 
 import http
 from typing import Any, Optional

--- a/gidgethub/abc.py
+++ b/gidgethub/abc.py
@@ -12,6 +12,7 @@ from . import (
     GitHubBroken,
     GraphQLAuthorizationFailure,
     GraphQLException,
+    HTTPException,
     QueryError,
     GraphQLResponseTypeError,
 )
@@ -149,9 +150,13 @@ class GitHubAPI(abc.ABC):
     ) -> int:
         """Send a GET request for a single item to the specifie endpoint and return its status code."""
 
-        _, _, status_code = await self._make_request(
-            "GET", url, url_vars, b"", accept, jwt=jwt, oauth_token=oauth_token
-        )
+        try:
+            _, _, status_code = await self._make_request(
+                "GET", url, url_vars, b"", accept, jwt=jwt, oauth_token=oauth_token
+            )
+        except HTTPException as e:
+            status_code = e.status_code
+
         return status_code
 
     async def getiter(

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -164,7 +164,7 @@ class TestGeneralGitHubAPI:
         gh = MockGitHubAPI(
             headers=headers, body=json.dumps(original_data).encode("utf8")
         )
-        data, _ = await gh._make_request(
+        data, _, _ = await gh._make_request(
             "GET", "/rate_limit", {}, "", sansio.accept_format()
         )
         assert data == original_data
@@ -175,8 +175,17 @@ class TestGeneralGitHubAPI:
         headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
         headers["link"] = "<https://api.github.com/fake?page=2>; " 'rel="next"'
         gh = MockGitHubAPI(headers=headers)
-        _, more = await gh._make_request("GET", "/fake", {}, "", sansio.accept_format())
+        _, more, _ = await gh._make_request("GET", "/fake", {}, "", sansio.accept_format())
         assert more == "https://api.github.com/fake?page=2"
+
+    @pytest.mark.asyncio
+    async def test_status_code(self):
+        """The status code is returned appropriately."""
+        headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
+        headers["link"] = "<https://api.github.com/fake?page=2>; " 'rel="next"'
+        gh = MockGitHubAPI(headers=headers)
+        _, _, status_code = await gh._make_request("GET", "/fake", {}, "", sansio.accept_format())
+        assert status_code == 200
 
 
 class TestGitHubAPIGetitem:
@@ -230,6 +239,20 @@ class TestGitHubAPIGetitem:
             )
 
         assert str(exc_info.value) == "Cannot pass both oauth_token and jwt."
+
+
+class TestGitHubAPIGetStatus:
+    @pytest.mark.asyncio
+    async def test_getstatus(self):
+        original_status = 204
+        headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
+        headers["content-type"] = "application/json; charset=UTF-8"
+        gh = MockGitHubAPI(
+            headers=headers, status_code=original_status
+        )
+        data = await gh.getstatus("/fake")
+        assert gh.method == "GET"
+        assert data == original_status
 
 
 class TestGitHubAPIGetiter:

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -254,6 +254,30 @@ class TestGitHubAPIGetStatus:
         assert gh.method == "GET"
         assert data == original_status
 
+    @pytest.mark.asyncio
+    async def test_getstatus_4xx(self):
+        original_status = 404
+        headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
+        headers["content-type"] = "application/json; charset=UTF-8"
+        gh = MockGitHubAPI(
+            headers=headers, status_code=original_status
+        )
+        data = await gh.getstatus("/fake")
+        assert gh.method == "GET"
+        assert data == original_status
+
+    @pytest.mark.asyncio
+    async def test_getstatus_5xx(self):
+        original_status = 504
+        headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
+        headers["content-type"] = "application/json; charset=UTF-8"
+        gh = MockGitHubAPI(
+            headers=headers, status_code=original_status
+        )
+        data = await gh.getstatus("/fake")
+        assert gh.method == "GET"
+        assert data == original_status
+
 
 class TestGitHubAPIGetiter:
     @pytest.mark.asyncio

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -175,7 +175,9 @@ class TestGeneralGitHubAPI:
         headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
         headers["link"] = "<https://api.github.com/fake?page=2>; " 'rel="next"'
         gh = MockGitHubAPI(headers=headers)
-        _, more, _ = await gh._make_request("GET", "/fake", {}, "", sansio.accept_format())
+        _, more, _ = await gh._make_request(
+            "GET", "/fake", {}, "", sansio.accept_format()
+        )
         assert more == "https://api.github.com/fake?page=2"
 
     @pytest.mark.asyncio
@@ -184,7 +186,9 @@ class TestGeneralGitHubAPI:
         headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
         headers["link"] = "<https://api.github.com/fake?page=2>; " 'rel="next"'
         gh = MockGitHubAPI(headers=headers)
-        _, _, status_code = await gh._make_request("GET", "/fake", {}, "", sansio.accept_format())
+        _, _, status_code = await gh._make_request(
+            "GET", "/fake", {}, "", sansio.accept_format()
+        )
         assert status_code == 200
 
 
@@ -247,9 +251,7 @@ class TestGitHubAPIGetStatus:
         original_status = 204
         headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
         headers["content-type"] = "application/json; charset=UTF-8"
-        gh = MockGitHubAPI(
-            headers=headers, status_code=original_status
-        )
+        gh = MockGitHubAPI(headers=headers, status_code=original_status)
         data = await gh.getstatus("/fake")
         assert gh.method == "GET"
         assert data == original_status
@@ -259,9 +261,7 @@ class TestGitHubAPIGetStatus:
         original_status = 404
         headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
         headers["content-type"] = "application/json; charset=UTF-8"
-        gh = MockGitHubAPI(
-            headers=headers, status_code=original_status
-        )
+        gh = MockGitHubAPI(headers=headers, status_code=original_status)
         data = await gh.getstatus("/fake")
         assert gh.method == "GET"
         assert data == original_status
@@ -271,9 +271,7 @@ class TestGitHubAPIGetStatus:
         original_status = 504
         headers = MockGitHubAPI.DEFAULT_HEADERS.copy()
         headers["content-type"] = "application/json; charset=UTF-8"
-        gh = MockGitHubAPI(
-            headers=headers, status_code=original_status
-        )
+        gh = MockGitHubAPI(headers=headers, status_code=original_status)
         data = await gh.getstatus("/fake")
         assert gh.method == "GET"
         assert data == original_status


### PR DESCRIPTION
This now supports API methods whose responses are expressed in a status
code, such as `/orgs/{org}/members/{username}` to determine if a group
contains a specific user.

-------

## Alternatives

Per the discussion on #188 this could have been achieved through refactoring `_make_request()` to split out request construction. Looking at the intermingling of the caching logic, the rate limit counter, and the header assembly, though, it looked like any method that made use of the full set of request construction would look remarkably similar to the full `_make_request()` call. As such, I augmented the return value to include the status code instead.

Closes #188