### PR TITLE
Update the intersphinx mapping to 1.0-style

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,7 +172,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/3/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 
 
 html_sidebars = {


### PR DESCRIPTION
-------

This is causing linter failures on new pull requests, since Sphinx has added a
deprecation warning for the old pre-1.0 format.

This change is modeled directly on the sample documentation at https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping'

Addresses linter issues in #192 and #194 